### PR TITLE
Change alg.garron.us links to alg.cubing.net.

### DIFF
--- a/lib/garronizer.rb
+++ b/lib/garronizer.rb
@@ -4,11 +4,10 @@ module RCDB
       def garronize(solve)
         params = {
           "alg" => escape_chars(solve.canonical_solution),
-          "ini" => escape_chars(solve.scramble),
-          "animtype" => animtype(solve),
-          "cube" => solve.puzzle.garronized_name,
-          "name" => garron_title(solve),
-          "displines" => display_lines(solve.canonical_solution),
+          "setup" => escape_chars(solve.scramble),
+          "type" => animtype(solve),
+          "puzzle" => solve.puzzle.garronized_name,
+          "title" => garron_title(solve),
         }
         garron_url_from_params(params)
       end
@@ -18,7 +17,7 @@ module RCDB
       def garron_url_from_params(params)
         url_params = params.reject { |k, v| v.blank? }
         .map { |k, v| "#{k}=#{v}"}.join("&")
-        "http://alg.garron.us/?#{url_params}"
+        "http://alg.cubing.net/?#{url_params}"
       end
 
       def escape_chars(alg)
@@ -28,13 +27,7 @@ module RCDB
       # if we don't have a scramble we need to set the 'animtype' to
       # have it set the cube up by doing the inverse of the solution
       def animtype(solve)
-        solve.scramble.blank? ? "solve" : ""
-      end
-
-      # when scrambles are too long, the solution being displayed covers the cube.
-      # we pick 12 arbitrarily to turn off the solution being displayed.
-      def display_lines(solution)
-        solution.lines.count > 12 ? "0" : ""
+        solve.scramble.blank? ? "reconstruction-end-with-setup" : "reconstruction"
       end
 
       def garron_title(solve)

--- a/views/solve_links.erb
+++ b/views/solve_links.erb
@@ -1,7 +1,7 @@
 <div class="solve-links">
   <% if @solve.puzzle.garronizable? %>
     <div class="garron solve-link">
-      <%= link_to "alg.garron", garronize(@solve), target: "_blank" %>
+      <%= link_to "alg.cubing.net", garronize(@solve), target: "_blank" %>
     </div>
   <% end %>
 


### PR DESCRIPTION
This is a minimal commit that changes the important parameters.
I didn't try to refactor anything.

Note that the full escaping mechanism is at: https://github.com/cubing/alg.cubing.net/blob/master/alg.js#L190
I'm eventually going to look into use cases to see if I want to escape other common things, but it's relatively stable for now. In particular, it handles shifting `-` and `_` "out of the way" so that escaped and non-escaped hyphens/underscores can be distinguished (they might be used in commments).
