### PR TITLE
Fix Roofpig and update to latest version

### DIFF
--- a/lib/roofpig_former.rb
+++ b/lib/roofpig_former.rb
@@ -2,8 +2,11 @@ module RCDB
   class RoofpigFormer
     class << self
       def roofpig_form(solve)
+        alg = remove_parens(solve.canonical_solution)
+        alg = remove_comments(alg)
+        alg = escape_chars(alg)
         roofpig_config_from_params(
-          "alg" => escape_chars(remove_comments(solve.canonical_solution)),
+          "alg" => alg,
         )
       end
 
@@ -18,6 +21,10 @@ module RCDB
 
       def remove_comments(alg)
         alg.gsub(%r(//.*?$), "")
+      end
+
+      def remove_parens(alg)
+        alg.tr("()","")
       end
 
       def escape_chars(alg)

--- a/public/dist/js/three_and_roofpig.min.js
+++ b/public/dist/js/three_and_roofpig.min.js
@@ -740,5 +740,835 @@ fragmentShader:"precision mediump float;\nuniform lowp int renderType;\nuniform 
 
 // --- Roofpig ---  License: https://github.com/larspetrus/Roofpig/blob/master/LICENSE
 
-(function(){var __indexOf=[].indexOf||function(item){for(var i=0,l=this.length;l>i;i++)if(i in this&&this[i]===item)return i;return-1};this.v3=function(x,y,z){return new THREE.Vector3(x,y,z)},this.v3_add=function(v1,v2){return v1.clone().add(v2)},this.v3_sub=function(v1,v2){return v1.clone().sub(v2)},this.v3_x=function(v,factor){return v.clone().multiplyScalar(factor)},this.standardize_name=function(name){var ordered_side,result,sides,_i,_len,_ref;for(sides=[name[0],name[1],name[2]],result="",_ref=["U","D","F","B","R","L"],_i=0,_len=_ref.length;_len>_i;_i++)ordered_side=_ref[_i],__indexOf.call(sides,ordered_side)>=0&&(result+=ordered_side);return result},this.side_name=function(side){return side?side.name||side:""},this.log_error=function(text){return console.log("RoofPig error: "+text)}}).call(this),function(){this.Layer=function(){function Layer(name,normal,cycle1,cycle2,uncycled,sticker_cycle){this.name=name,this.normal=normal,this.cycle1=cycle1,this.cycle2=cycle2,this.sticker_cycle=sticker_cycle,this.positions=this.cycle1.concat(this.cycle2,uncycled)}var all,sides;return Layer.by_name=function(name){return all[name]},Layer.side_by_name=function(name){return sides[name]},Layer.R=new Layer("R",v3(-1,0,0),["UFR","DFR","DBR","UBR"],["UR","FR","DR","BR"],["R"],{B:"D",D:"F",F:"U",U:"B",L:"L",R:"R"}),Layer.L=new Layer("L",v3(1,0,0),["UBL","DBL","DFL","UFL"],["BL","DL","FL","UL"],["L"],{B:"U",U:"F",F:"D",D:"B",L:"L",R:"R"}),Layer.F=new Layer("F",v3(0,1,0),["DFL","DFR","UFR","UFL"],["FL","DF","FR","UF"],["F"],{U:"R",R:"D",D:"L",L:"U",F:"F",B:"B"}),Layer.B=new Layer("B",v3(0,-1,0),["UBL","UBR","DBR","DBL"],["UB","BR","DB","BL"],["B"],{U:"L",L:"D",D:"R",R:"U",F:"F",B:"B"}),Layer.U=new Layer("U",v3(0,0,1),["UBR","UBL","UFL","UFR"],["UR","UB","UL","UF"],["U"],{F:"R",R:"B",B:"L",L:"F",U:"U",D:"D"}),Layer.D=new Layer("D",v3(0,0,-1),["DFR","DFL","DBL","DBR"],["DF","DL","DB","DR"],["D"],{F:"L",L:"B",B:"R",R:"F",U:"U",D:"D"}),Layer.M=new Layer("M",Layer.L.normal,["UF","UB","DB","DF"],["U","B","D","F"],[],Layer.L.sticker_cycle),Layer.E=new Layer("E",Layer.D.normal,["BL","BR","FR","FL"],["L","B","R","F"],[],Layer.D.sticker_cycle),Layer.S=new Layer("S",Layer.F.normal,["DL","DR","UR","UL"],["L","D","R","U"],[],Layer.F.sticker_cycle),Layer.prototype.shift=function(side_name,turns){var n,result,_i;if(!this.sticker_cycle[side_name])return null;if(1>turns)throw new Error("Invalid turn number: '"+turns+"'");for(result=side_name,n=_i=1;turns>=1?turns>=_i:_i>=turns;n=turns>=1?++_i:--_i)result=this.sticker_cycle[result];return result},all={R:Layer.R,L:Layer.L,F:Layer.F,B:Layer.B,D:Layer.D,U:Layer.U,M:Layer.M,E:Layer.E,S:Layer.S},sides={R:Layer.R,L:Layer.L,F:Layer.F,B:Layer.B,D:Layer.D,U:Layer.U},Layer}()}.call(this),function(){this.TimedChanger=function(){function TimedChanger(duration){this.duration=duration,this.start_time=(new Date).getTime(),this.last_time=this.start_time}return TimedChanger.prototype.update=function(now){return this._finished?void 0:now>this.start_time+this.duration?this.finish():this._make_change(now)},TimedChanger.prototype.finish=function(){return this.finished()?void 0:(this._make_change(this.start_time+this.duration),this._finished=!0)},TimedChanger.prototype.finished=function(){return this._finished},TimedChanger.prototype._make_change=function(to_time){return this.do_change(to_time-this.last_time),this.last_time=to_time},TimedChanger}()}.call(this),function(){var __hasProp={}.hasOwnProperty,__extends=function(child,parent){function ctor(){this.constructor=child}for(var key in parent)__hasProp.call(parent,key)&&(child[key]=parent[key]);return ctor.prototype=parent.prototype,child.prototype=new ctor,child.__super__=parent.prototype,child};this.CameraMovement=function(_super){function CameraMovement(camera,axis,angle_to_turn,turn_time,animate){this.camera=camera,this.axis=axis,this.angle_to_turn=angle_to_turn,CameraMovement.__super__.constructor.call(this,turn_time),animate||this.finish()}return __extends(CameraMovement,_super),CameraMovement.prototype.do_change=function(time_diff){return this.camera.rotate(this.axis,time_diff*this.angle_to_turn/this.duration)},CameraMovement}(TimedChanger)}.call(this),function(){var __hasProp={}.hasOwnProperty,__extends=function(child,parent){function ctor(){this.constructor=child}for(var key in parent)__hasProp.call(parent,key)&&(child[key]=parent[key]);return ctor.prototype=parent.prototype,child.prototype=new ctor,child.__super__=parent.prototype,child};this.MoveExecution=function(_super){function MoveExecution(pieces,axis,angle_to_turn,turn_time,animate){this.pieces=pieces,this.axis=axis,this.angle_to_turn=angle_to_turn,MoveExecution.__super__.constructor.call(this,turn_time),animate||this.finish()}return __extends(MoveExecution,_super),MoveExecution.prototype.do_change=function(time_diff){var angle_diff,piece,_i,_len,_ref,_results;for(angle_diff=time_diff*this.angle_to_turn/this.duration,_ref=this.pieces,_results=[],_i=0,_len=_ref.length;_len>_i;_i++)piece=_ref[_i],_results.push(this._rotateAroundWorldAxis(piece,angle_diff));return _results},MoveExecution.prototype._rotateAroundWorldAxis=function(object,radians){var rotWorldMatrix;return rotWorldMatrix=new THREE.Matrix4,rotWorldMatrix.makeRotationAxis(this.axis,radians),rotWorldMatrix.multiply(object.matrix),object.matrix=rotWorldMatrix,object.rotation.setFromRotationMatrix(object.matrix)},MoveExecution}(TimedChanger)}.call(this),function(){this.Move=function(){function Move(code,world3d,speed){var _ref;this.world3d=world3d,this.speed=null!=speed?speed:400,_ref=Move._parse_code(code),this.layer=_ref[0],this.turns=_ref[1],this.is_rotation=_ref[2],this.turn_time=this.speed/2*(1+Math.abs(this.turns))}return Move._parse_code=function(code){var is_rotation,layer,turns,_ref;if(turns=Move.parse_turns(code.substring(1)),is_rotation=">"===(_ref=code.substring(1))||">>"===_ref||"<"===_ref||"<<"===_ref,layer=Layer.by_name(code[0]),!layer||!turns)throw new Error("Invalid Move code '"+code+"'");return[layer,turns,is_rotation]},Move.parse_turns=function(tcode){switch(tcode){case"1":case"":case">":return 1;case"2":case"²":case">>":return 2;case"3":case"'":case"<":return-1;case"Z":case"2'":case"<<":return-2}},Move.prototype["do"]=function(){return this._do(this.turns,!1)},Move.prototype.undo=function(){return this._do(-this.turns,!1)},Move.prototype.mix=function(){return this.is_rotation?void 0:this.undo()},Move.prototype.show_do=function(){return this._do(this.turns,!0)},Move.prototype.show_undo=function(){return this._do(-this.turns,!0)},Move.prototype._do=function(do_turns,animate){return this.is_rotation?new CameraMovement(this.world3d.camera,this.layer.normal,do_turns*Math.PI/2,this.turn_time,animate):(this.world3d.pieces.move(this.layer,do_turns),new MoveExecution(this.world3d.pieces.on(this.layer),this.layer.normal,do_turns*-Math.PI/2,this.turn_time,animate))},Move.prototype.count=function(count_rotations){return count_rotations||!this.is_rotation?1:0},Move.prototype.to_s=function(){var turn_codes;return turn_codes={"true":{1:">",2:">>","-1":"<","-2":"<<"},"false":{1:"",2:"2","-1":"'","-2":"Z"}},""+this.layer.name+turn_codes[this.is_rotation][this.turns]},Move.displayify=function(move_text,algdisplay){var result;return result=move_text.replace("Z",algdisplay.Zcode),algdisplay.fancy2s&&(result=result.replace("2","²")),result},Move.prototype.display_text=function(algdisplay){return algdisplay.rotations||!this.is_rotation?Move.displayify(this.to_s(),algdisplay):""},Move}()}.call(this),function(){this.ConcurrentChangers=function(){function ConcurrentChangers(sub_changers){this.sub_changers=sub_changers}return ConcurrentChangers.prototype.update=function(now){var changer,_i,_len,_ref,_results;for(_ref=this.sub_changers,_results=[],_i=0,_len=_ref.length;_len>_i;_i++)changer=_ref[_i],_results.push(changer.update(now));return _results},ConcurrentChangers.prototype.finish=function(){var changer,_i,_len,_ref,_results;for(_ref=this.sub_changers,_results=[],_i=0,_len=_ref.length;_len>_i;_i++)changer=_ref[_i],_results.push(changer.finish());return _results},ConcurrentChangers.prototype.finished=function(){var changer,_i,_len,_ref;for(_ref=this.sub_changers,_i=0,_len=_ref.length;_len>_i;_i++)if(changer=_ref[_i],!changer.finished())return!1;return!0},ConcurrentChangers}()}.call(this),function(){this.CompositeMove=function(){function CompositeMove(move_codes,world3d,speed,official_text){var code;this.official_text=null!=official_text?official_text:null,this.moves=function(){var _i,_len,_ref,_results;for(_ref=move_codes.split("+"),_results=[],_i=0,_len=_ref.length;_len>_i;_i++)code=_ref[_i],_results.push(new Move(code,world3d,speed));return _results}()}return CompositeMove.prototype["do"]=function(){return new ConcurrentChangers(this.moves.map(function(move){return move["do"]()}))},CompositeMove.prototype.undo=function(){return new ConcurrentChangers(this.moves.map(function(move){return move.undo()}))},CompositeMove.prototype.mix=function(){return new ConcurrentChangers(this.moves.map(function(move){return move.mix()}))},CompositeMove.prototype.show_do=function(){return new ConcurrentChangers(this.moves.map(function(move){return move.show_do()}))},CompositeMove.prototype.show_undo=function(){return new ConcurrentChangers(this.moves.map(function(move){return move.show_undo()}))},CompositeMove.prototype.count=function(count_rotations){var move,result,_i,_len,_ref;if(this.official_text)return 1;for(result=0,_ref=this.moves,_i=0,_len=_ref.length;_len>_i;_i++)move=_ref[_i],result+=move.count(count_rotations);return result},CompositeMove.prototype.to_s=function(){return"("+this.moves.map(function(move){return move.to_s()}).join(" ")+")"},CompositeMove.prototype.display_text=function(algdisplay){var display_texts,text;return this.official_text?Move.displayify(this.official_text,algdisplay):(display_texts=this.moves.map(function(move){return move.display_text(algdisplay)}),function(){var _i,_len,_results;for(_results=[],_i=0,_len=display_texts.length;_len>_i;_i++)text=display_texts[_i],text&&_results.push(text);return _results}().join("+"))},CompositeMove}()}.call(this),function(){this.AlgAnimation=function(){function AlgAnimation(alg){this.alg=alg,this._next_alg_move()}return AlgAnimation.prototype.update=function(now){return this._finished?void 0:(this.changer.finished()&&this._next_alg_move(),this.changer.update(now))},AlgAnimation.prototype.finish=function(){},AlgAnimation.prototype.finished=function(){return this._finished},AlgAnimation.prototype._next_alg_move=function(){return this.alg.at_end()||!this.alg.playing?this._finished=!0:this.changer=this.alg.next_move().show_do()},AlgAnimation}()}.call(this),function(){this.Alg=function(){function Alg(move_codes,world3d,algdisplay,speed,dom){var code,_i,_len,_ref;if(this.move_codes=move_codes,this.world3d=world3d,this.algdisplay=algdisplay,this.speed=speed,this.dom=dom,!this.move_codes||""===this.move_codes)throw new Error("Invalid alg: '"+this.move_codes+"'");for(this.moves=[],_ref=this.move_codes.split(" "),_i=0,_len=_ref.length;_len>_i;_i++)code=_ref[_i],code.length>0&&this.moves.push(this._make_move(code));this.next=0,this.playing=!1,this._update_dom("first time")}var turn_codes;return Alg.prototype.next_move=function(){return this.at_end()?void 0:(this.next+=1,this.at_end()&&(this.playing=!1),this._update_dom(),this.moves[this.next-1])},Alg.prototype.prev_move=function(){return this.at_start()?void 0:(this.next-=1,this._update_dom(),this.moves[this.next])},Alg.prototype.play=function(){return this.playing=!0,this._update_dom(),new AlgAnimation(this)},Alg.prototype.stop=function(){return this.playing=!1,this._update_dom()},Alg.prototype.to_end=function(){var _results;for(_results=[];!this.at_end();)_results.push(this.next_move()["do"]());return _results},Alg.prototype.to_start=function(){var _results;for(_results=[];!this.at_start();)_results.push(this.prev_move().undo());return _results},Alg.prototype.at_start=function(){return 0===this.next},Alg.prototype.at_end=function(){return this.next===this.moves.length},Alg.prototype.mix=function(){var _results;for(this.next=this.moves.length,_results=[];!this.at_start();)_results.push(this.prev_move().mix());return _results},Alg.prototype.to_s=function(){return this.moves.map(function(move){return move.to_s()}).join(" ")},Alg.prototype.display_text=function(){var active,future,i,move,past,text,_i,_len,_ref;for(active=past=[],future=[],_ref=this.moves,i=_i=0,_len=_ref.length;_len>_i;i=++_i)move=_ref[i],this.next===i&&(active=future),text=move.display_text(this.algdisplay),text&&active.push(text);return{past:past.join(" "),future:future.join(" ")}},turn_codes={"-2":["Z","2"],"-1":["'",""],1:["","'"],2:["2","Z"]},Alg.prototype._make_move=function(code){var moves,t1,t2,_ref,_ref1,_ref2,_ref3;return code.indexOf("+")>-1?new CompositeMove(code,this.world3d,this.speed):"x"===(_ref=code[0])||"y"===_ref||"z"===_ref?(_ref1=turn_codes[Move.parse_turns(code.substring(1))],t1=_ref1[0],t2=_ref1[1],moves=function(){switch(code[0]){case"x":return"R"+t1+"+M"+t2+"+L"+t2;case"y":return"U"+t1+"+E"+t2+"+D"+t2;case"z":return"F"+t1+"+S"+t1+"+B"+t2}}(),new CompositeMove(moves,this.world3d,this.speed,code)):"w"!==code[1]||"U"!==(_ref2=code[0])&&"D"!==_ref2&&"L"!==_ref2&&"R"!==_ref2&&"F"!==_ref2&&"B"!==_ref2?new Move(code,this.world3d,this.speed):(_ref3=turn_codes[Move.parse_turns(code.substring(2))],t1=_ref3[0],t2=_ref3[1],moves=function(){switch(code[0]){case"R":return"R"+t1+"+M"+t2;case"L":return"L"+t1+"+M"+t1;case"U":return"U"+t1+"+E"+t2;case"D":return"D"+t1+"+E"+t1;case"F":return"F"+t1+"+S"+t1;case"B":return"B"+t1+"+S"+t2}}(),new CompositeMove(moves,this.world3d,this.speed,code))},Alg.prototype._update_dom=function(time){return null==time&&(time="later"),this.dom?("first time"===time&&this.dom.init_alg_text(this.display_text().future),this.dom.alg_changed(this.playing,this.at_start(),this.at_end(),this._count_text(),this.display_text())):void 0},Alg.prototype._count_text=function(){var count,current,i,move,total,_i,_len,_ref;for(total=current=0,_ref=this.moves,i=_i=0,_len=_ref.length;_len>_i;i=++_i)move=_ref[i],count=move.count(this.algdisplay.rotations),this.next>i&&(current+=count),total+=count;return""+current+"/"+total},Alg}()}.call(this),function(){this.Camera=function(){function Camera(hover,pov_code){this.pov_code=pov_code,this.cam=new THREE.PerspectiveCamera(this._view_angle(hover,DISTANCE),1,1,100),this.to_pov()}var DISTANCE;return DISTANCE=25,Camera.prototype.to_pov=function(){var pov;return pov=Camera._POVs[this.pov_code],pov||(pov=Camera._POVs.Ufr,log_error("Invalid POV '"+this.pov_code+"'. Using Ufr")),this.cam.position.copy(pov.pos),this.cam.up.copy(pov.up),this.user_dir={dr:pov.xn.clone(),dl:pov.yn.clone(),up:pov.zn.clone()},this._cam_moved()},Camera.prototype.rotate=function(axis,angle){var v,_i,_len,_ref;for(_ref=[this.cam.position,this.cam.up,this.user_dir.dl,this.user_dir.dr,this.user_dir.up],_i=0,_len=_ref.length;_len>_i;_i++)v=_ref[_i],v.applyAxisAngle(axis,angle);return this._cam_moved()},Camera.prototype.bend=function(dx,dy){var axis,v,v1,v2,_i,_len,_ref;for(v1=v3_x(this.user_dir.up,dx),v2=v3_sub(this.user_dir.dr,this.user_dir.dl).normalize().multiplyScalar(dy),axis=v3_add(v1,v2).normalize(),this.cam.position=this.unbent_position.clone(),this.cam.up=this.unbent_up.clone(),_ref=[this.cam.position,this.cam.up],_i=0,_len=_ref.length;_len>_i;_i++)v=_ref[_i],v.applyAxisAngle(axis,Math.sqrt(dx*dx+dy*dy));return this.cam.lookAt(v3(0,0,0))},Camera.prototype._view_angle=function(hover,cam_pos){var adjustment_factor,distance,max_cube_size;return max_cube_size=2*Math.sqrt(hover*hover+4*hover+13),distance=Math.sqrt(3*cam_pos*cam_pos)-2,adjustment_factor=1.015+.13*(5-hover)/4,2*adjustment_factor*Math.atan(max_cube_size/(2*distance))*(180/Math.PI)},Camera.prototype._cam_moved=function(){return this.cam.lookAt(v3(0,0,0)),this.unbent_up=this.cam.up.clone(),this.unbent_position=this.cam.position.clone()},Camera._flip=function(pov,parity){var _ref;return parity>0&&(_ref=[pov.yn,pov.xn],pov.xn=_ref[0],pov.yn=_ref[1]),pov},Camera._set_perms=function(povs,a,b,c,value){return povs[a+b+c]=povs[a+c+b]=povs[b+a+c]=povs[b+c+a]=povs[c+a+b]=povs[c+b+a]=value},Camera._POVs=function(){var parity,pos,result,x,xl,xn,xu,y,yl,yn,yu,z,zl,zn,zu,_i,_j,_k,_len,_len1,_len2,_ref,_ref1,_ref2,_ref3,_ref4,_ref5;for(result={},_ref=[Layer.U,Layer.D],_i=0,_len=_ref.length;_len>_i;_i++)for(z=_ref[_i],_ref1=[z.name,z.name.toLowerCase(),z.normal.clone()],zu=_ref1[0],zl=_ref1[1],zn=_ref1[2],_ref2=[Layer.F,Layer.B],_j=0,_len1=_ref2.length;_len1>_j;_j++)for(y=_ref2[_j],_ref3=[y.name,y.name.toLowerCase(),y.normal.clone()],yu=_ref3[0],yl=_ref3[1],yn=_ref3[2],_ref4=[Layer.R,Layer.L],_k=0,_len2=_ref4.length;_len2>_k;_k++)x=_ref4[_k],_ref5=[x.name,x.name.toLowerCase(),x.normal.clone()],xu=_ref5[0],xl=_ref5[1],xn=_ref5[2],pos=v3(xn.x,yn.y,zn.z).multiplyScalar(DISTANCE),parity=xn.x*yn.y*zn.z,Camera._set_perms(result,zu,yl,xl,Camera._flip({pos:pos,up:zn,zn:zn,yn:yn,xn:xn},parity)),Camera._set_perms(result,zl,yu,xl,Camera._flip({pos:pos,up:yn,zn:yn,yn:xn,xn:zn},parity)),Camera._set_perms(result,zl,yl,xu,Camera._flip({pos:pos,up:xn,zn:xn,yn:zn,xn:yn},parity));return result}(),Camera}()}.call(this),function(){this.Cubexp=function(){function Cubexp(cubexp_string){var excluded,exp,expression,piece,side,_i,_j,_k,_l,_len,_len1,_len2,_len3,_len4,_len5,_len6,_len7,_m,_n,_o,_p,_ref,_ref1,_ref2;for(null==cubexp_string&&(cubexp_string=""),this.matches={},_i=0,_len=PIECE_NAMES.length;_len>_i;_i++)piece=PIECE_NAMES[_i],this.matches[piece]={};for(_ref=cubexp_string.split(" "),_j=0,_len1=_ref.length;_len1>_j;_j++)switch(expression=_ref[_j],exp=this._parse(expression),exp.type){case"XYZ":this._add_match(exp.piece,exp.type_filter,exp.sides);break;case"X-":for(_k=0,_len2=PIECE_NAMES.length;_len2>_k;_k++){for(piece=PIECE_NAMES[_k],excluded=!1,_ref1=exp.piece.split(""),_l=0,_len3=_ref1.length;_len3>_l;_l++)side=_ref1[_l],excluded||(excluded=piece.indexOf(side)>-1);excluded||this._add_match(piece,exp.type_filter)}break;case"X*":for(_m=0,_len4=PIECE_NAMES.length;_len4>_m;_m++)for(piece=PIECE_NAMES[_m],_ref2=exp.piece.split(""),_n=0,_len5=_ref2.length;_len5>_n;_n++)side=_ref2[_n],piece.indexOf(side)>-1&&this._add_match(piece,exp.type_filter);break;case"*":for(_o=0,_len6=PIECE_NAMES.length;_len6>_o;_o++)piece=PIECE_NAMES[_o],this._add_match(piece,exp.type_filter);break;case"x":for(_p=0,_len7=PIECE_NAMES.length;_len7>_p;_p++)piece=PIECE_NAMES[_p],piece.indexOf(exp.piece[0])>-1&&this._add_match(piece,exp.type_filter,exp.piece);break;default:log_error("Ignored unrecognized Cubexp '"+expression+"'.")}}var PIECE_NAMES;return PIECE_NAMES=["B","BL","BR","D","DB","DBL","DBR","DF","DFL","DFR","DL","DR","F","FL","FR","L","R","U","UB","UBL","UBR","UF","UFL","UFR","UL","UR"],Cubexp.prototype.matches_sticker=function(piece,side){return null!=this.matches[standardize_name(piece)][side_name(side)]},Cubexp.prototype.selected_pieces=function(){var code,piece,result,selected,selections,side,_i,_len,_ref,_ref1;result=[],_ref=this.matches;for(piece in _ref){for(selections=_ref[piece],code="",selected=!1,_ref1=piece.split(""),_i=0,_len=_ref1.length;_len>_i;_i++)side=_ref1[_i],selected||(selected=selections[side]),code+=selections[side]?side:side.toLowerCase();selected&&result.push(code)}return result},Cubexp.prototype._add_match=function(piece,type_filter,sides){var piece_type,side,_i,_len,_ref,_results;if(null==sides&&(sides=piece),piece_type="mec"[piece.length-1],!type_filter||type_filter.indexOf(piece_type)>-1){for(_ref=sides.split(""),_results=[],_i=0,_len=_ref.length;_len>_i;_i++)side=_ref[_i],_results.push(this.matches[piece][side]=!0);return _results}},Cubexp.prototype._parse=function(expression){var exp,last_char,result,_ref;switch(result={},_ref=expression.split("/"),exp=_ref[0],result.type_filter=_ref[1],result.piece=standardize_name(exp.toUpperCase()),last_char=exp[exp.length-1]){case"*":result.type="*"===exp?"*":"X*";break;case"-":result.type="X-";break;default:exp===result.piece.toLowerCase()?result.type="x":(result.type="XYZ",result.sides=standardize_name(exp))}return result},Cubexp}()}.call(this),function(){this.Tweaks=function(){function Tweaks(expressions){var expression,i,piece,piece_exp,side,what,where,_i,_j,_k,_l,_len,_len1,_len2,_len3,_ref,_ref1,_ref2,_ref3,_ref4;if(this.tweaks={},expressions)for(_ref=expressions.split(" "),_i=0,_len=_ref.length;_len>_i;_i++)if(expression=_ref[_i],_ref1=expression.split(":"),what=_ref1[0],where=_ref1[1],where)if(1===what.length)for(_ref2=new Cubexp(where).selected_pieces(),_j=0,_len1=_ref2.length;_len1>_j;_j++)for(piece_exp=_ref2[_j],_ref3=piece_exp.split(""),_k=0,_len2=_ref3.length;_len2>_k;_k++)side=_ref3[_k],this._add(piece_exp.toUpperCase(),side,what);else for(piece=standardize_name(where.toUpperCase()),_ref4=where.split(""),i=_l=0,_len3=_ref4.length;_len3>_l;i=++_l)side=_ref4[i],this._add(piece,side,what[i])}return Tweaks.prototype.for_sticker=function(piece,side){var match;return match=this.tweaks[standardize_name(piece)]||{},match[side_name(side)]||[]},Tweaks.prototype._add=function(piece,side,what){var _base,_base1;return Layer.side_by_name(side)?(null==(_base=this.tweaks)[piece]&&(_base[piece]={}),null==(_base1=this.tweaks[piece])[side]&&(_base1[side]=[]),this.tweaks[piece][side].push(what)):void 0},Tweaks}()}.call(this),function(){this.Colors=function(){function Colors(colored,solved,tweaks,colors){null==colors&&(colors=""),this.colored=new Cubexp(colored||"*"),this.solved=new Cubexp(solved),this.tweaks=new Tweaks(tweaks),this.side_colors=Colors._set_colors(colors)}var DEFAULT_COLORS;return Colors.prototype.to_draw=function(piece_name,side){var result,tweak,_i,_len,_ref;for(result={hovers:!1,color:this.of(side)},this.solved.matches_sticker(piece_name,side)?result.color=this.of("solved"):this.colored.matches_sticker(piece_name,side)?result.hovers=!0:result.color=this.of("ignored"),_ref=this.tweaks.for_sticker(piece_name,side),_i=0,_len=_ref.length;_len>_i;_i++)switch(tweak=_ref[_i],result.hovers=!0,tweak){case"X":case"x":result.x_color={X:"black",x:"white"}[tweak];break;default:Layer.by_name(tweak)?result.color=this.of(tweak):log_error("Unknown tweak: '"+tweak+"'")}return result},Colors.prototype.of=function(sticker_type){var type;if(type=sticker_type.name||sticker_type,!this.side_colors[type])throw new Error("Unknown sticker type '"+sticker_type+"'");return this.side_colors[type]},DEFAULT_COLORS={g:"#0d0",b:"#07f",r:"red",o:"orange",y:"yellow",w:"#eee"},Colors._set_colors=function(overrides){var color,dc,override,result,type,_i,_len,_ref,_ref1;for(dc=DEFAULT_COLORS,result={R:dc.g,L:dc.b,F:dc.r,B:dc.o,U:dc.y,D:dc.w,solved:"#444",ignored:"#888",cube:"black"},_ref=overrides.split(" "),_i=0,_len=_ref.length;_len>_i;_i++)override=_ref[_i],_ref1=override.split(":"),type=_ref1[0],color=_ref1[1],type={s:"solved",i:"ignored",c:"cube"}[type]||type,result[type]=DEFAULT_COLORS[color]||color;return result},Colors}()}.call(this),function(){this.Config=function(){function Config(config_string){this.raw_input=Config._parse(config_string),this.base=this.base_config(this.raw_input.base,config_string),this.alg=this.raw("alg"),this.algdisplay=this._alg_display(),this.colors=new Colors(this.raw("colored"),this.raw("solved"),this.raw("tweaks"),this.raw("colors")),this.flags=this.raw("flags"),this.hover=this._hover(),this.pov=this.raw("pov","Ufr"),this.setup=this.raw("setupmoves"),this.speed=this.raw("speed",400)}return Config.prototype.flag=function(name){return this.flags.indexOf(name)>-1},Config.prototype.raw=function(name,default_value){return null==default_value&&(default_value=""),this.raw_input[name]||this.base.raw(name)||default_value},Config.prototype.base_config=function(base_id,config_string){var base_string;return base_string=window["ROOFPIG_CONF_"+base_id],base_id&&!base_string&&log_error("'ROOFPIG_CONF_"+base_id+"' does not exist"),config_string&&config_string===base_string&&(log_error(""+base_string+" tries to inherit from itself."),base_string=null),base_string?new Config(base_string):{raw:function(){}}},Config.prototype._hover=function(){var raw_hover;switch(raw_hover=this.raw("hover","near")){case"none":return 1;case"near":return 2;case"far":return 7.1;default:return raw_hover}},Config.prototype._alg_display=function(){var ad,result;return ad=this.raw("algdisplay"),result={},result.fancy2s=ad.indexOf("fancy2s")>-1,result.rotations=ad.indexOf("rotations")>-1,result.Zcode="2",ad.indexOf("2p")>-1&&(result.Zcode="2'"),ad.indexOf("Z")>-1&&(result.Zcode="Z"),result},Config._parse=function(config_string){var conf,eq_pos,key,result,value,_i,_len,_ref;if(!config_string)return{};for(result={},_ref=config_string.split("|"),_i=0,_len=_ref.length;_len>_i;_i++)conf=_ref[_i],eq_pos=conf.indexOf("="),key=conf.substring(0,eq_pos).trim(),value=conf.substring(eq_pos+1).trim(),result[key]=value;return result},Config}()}.call(this),function(){this.Css=function(){function Css(){}var dark,light,shadow;return light="#ededed",dark="#bbb",shadow="#ffffff",Css.CODE="<style>\n.roofpig-button {\n  font-family: Lucida Sans Unicode, Lucida Grande, sans-serif;\n  font-weight: normal;\n  font-style: normal;\n  padding: 0;\n  box-shadow: inset 0px 1px 0px 0px "+shadow+";\n  background-color: "+light+";\n  border: 1px solid #dcdcdc;\n  outline: none;\n  border-radius: 2px;\n  text-indent: 0;\n  display: inline-block;\n  text-decoration: none;\n  text-align: center;\n  text-shadow: 1px 1px 0 "+shadow+";\n}\n.roofpig-button-enabled {\n  background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, "+light+"), color-stop(1, "+dark+"));\n  background: -moz-linear-gradient(center top, "+light+" 5%, "+dark+" 100%);\n  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='"+light+"', endColorstr='"+dark+"');\n}\n.roofpig-button-enabled:hover {\n  background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, "+dark+"), color-stop(1, "+light+"));\n  background: -moz-linear-gradient(center top, "+dark+" 5%, "+light+" 100%);\n  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='"+dark+"', endColorstr='"+light+"');\n}\n.roofpig-button-enabled:active, .roofpig-button-fake-active {\n  position: relative;\n  top: 2px;\n}\n\n.roofpig-count {\n  font-weight: normal;\n  font-style: normal;\n  color: black;\n  text-align: right;\n  float: right;\n}\n\n.roofpig-algtext {\n  background-color: #eee;\n  margin-bottom: 2px;\n  font-weight: normal;\n  font-style: normal;\n  color: black;\n}\n.roofpig-past-algtext {\n  background-color: #ff9;\n}\n\n.roofpig-help-button {\n  font-size: 14px;\n  height: 20px;\n  width: 20px;\n  position: absolute;\n  right: 2px;\n  top: 3px;\n\n  color: #ddd;\n  text-align: center;\n  border-radius: 8px;\n}\n.roofpig-help-button:hover {\n  color: black;\n  background-color: rgba(220, 220, 220, 0.7);\n}\n.roofpig-help-button:active {\n  background-color: #aaa;\n}\n\n.roofpig-help {\n  position: absolute;\n  top: -1px;\n  white-space: nowrap;\n\n  font-size: 10px;\n  font-weight: normal;\n  font-style: normal;\n  color: black;\n  text-align: left;\n  background-color: rgba(255, 255, 255, 0.94);\n\n  border: 1px solid #aaa;\n  padding: 0 4px 4px 4px;\n}\n.roofpig-help div {\n  margin: 2px 0;\n}\n.roofpig-help span {\n  font-size: 11px;\n  padding: 0 2px;\n  background-color: #ddd;\n}\n</style>",Css}()}.call(this),function(){this.Dom=function(){function Dom(cube_id,div,renderer){this.cube_id=cube_id,this.div=div,this.div.css({position:"relative","font-family":'"Lucida Sans Unicode", "Lucida Grande", sans-serif'}),this.has_focus(!1),this.div.data("cube_id",this.cube_id),renderer.setSize(this.div.width(),this.div.width()),this.div.append(renderer.domElement),this.scale=this.div.width()/400,this.hscale=Math.max(this.scale,.375)}var LUCIDA_WIDTHS;return Dom.prototype.has_focus=function(has_it){var color,cursor;return color=has_it?"gray":"#eee",cursor=has_it?"pointer":"default",this.div.css({border:"2px solid "+color,cursor:cursor})},Dom.prototype.alg_changed=function(is_playing,at_start,at_end,count_text,alg_texts){var button,_i,_j,_len,_len1,_ref,_ref1;if(is_playing)for(_ref=this.buttons,_i=0,_len=_ref.length;_len>_i;_i++)button=_ref[_i],button===this.play?button.hide():this._show(button,button===this.pause);else for(_ref1=this.buttons,_j=0,_len1=_ref1.length;_len1>_j;_j++)switch(button=_ref1[_j]){case this.reset:case this.prev:this._show(button,!at_start);break;case this.next:case this.play:this._show(button,!at_end);break;case this.pause:button.hide()}return this.play_or_pause=is_playing?this.pause:this.play,this.count.html(count_text),this.alg_text?(this.alg_past.text(alg_texts.past),this.alg_future.text(" "+alg_texts.future)):void 0},Dom.prototype.show_help=function(){return this.help=$("<div/>").addClass("roofpig-help"),this.help.append($("<div>Keyboard shortcuts</div>").css({"text-align":"center","font-weight":"bold"}),"<div><span>→</span> - Next move</div>","<div/><span>←</span> - Previous move</div>","<div/><span>⇧</span>+<span>→</span> - To end</div>","<div/><span>⇧</span>+<span>←</span> - To start</div>","<div/><span>&nbsp;space&nbsp;</span> - Play/Pause</div>","<div/><span>Tab</span> - Next Cube</div>"),this.div.append(this.help),this.help.css({right:""+(this.div.width()-this.help.outerWidth())/2+"px"})},Dom.prototype.remove_help=function(){var was_removed;return this.help&&(this.help.remove(),this.help=null,was_removed=!0),was_removed},Dom.prototype.add_alg_area=function(showalg){return this.div.append($("<div/>",{text:"?",id:"help-"+this.cube_id}).addClass("roofpig-help-button")),this.alg_area=$("<div/>").height(this.div.height()-this.div.width()).width(this.div.width()).css({"border-top":"1px solid #ccc"}),this.div.append(this.alg_area),showalg&&(this.alg_text=$("<div/>").width(this.div.width()).addClass("roofpig-algtext"),this.alg_area.append(this.alg_text),this.alg_past=$("<span/>").addClass("roofpig-past-algtext"),this.alg_future=$("<span/>"),this.alg_text.append(this.alg_past,this.alg_future)),this.reset=this._make_button("↩","reset"),this.prev=this._make_button("-","prev"),this.next=this._make_button("+","next"),this.pause=this._make_button("Ⅱ","pause"),this.play=this._make_button("▶","play"),this.count=this._make_count_area(),this.buttons=[this.reset,this.prev,this.next,this.pause,this.play]},LUCIDA_WIDTHS={M:108,"+":100,">":100,"<":100,w:98,D:94,U:87,2:80,R:80,x:78,Z:77,B:73,z:73,F:68,E:68,S:68,L:67,y:65,"²":53," ":40,"'":29},Dom.prototype.init_alg_text=function(text){var char,font_size,width,_i,_len,_ref;if(this.alg_text){for(width=0,_ref=text.split(""),_i=0,_len=_ref.length;_len>_i;_i++)char=_ref[_i],width+=LUCIDA_WIDTHS[char]||80,LUCIDA_WIDTHS[char]||log_error("Unknown char width: '"+char+"'");return font_size=24*this.scale*Math.min(1,1970/width),this.alg_text.height(1.2*font_size).css({"font-size":font_size})}},Dom.prototype._show=function(button,enabled){return button.show(),enabled?(button.removeAttr("disabled"),button.addClass("roofpig-button-enabled")):(button.attr("disabled","disabled"),button.removeClass("roofpig-button-enabled"))},Dom.prototype._make_button=function(text,name){var button;return button=$("<button/>",{text:text,id:""+name+"-"+this.cube_id}),this.alg_area.append(button),button.addClass("roofpig-button"),button.css({"font-size":28*this.hscale,"float":"left",height:40*this.hscale,width:76*this.scale})},Dom.prototype._make_count_area=function(){var count_div;return count_div=$("<div/>",{id:"count-"+this.cube_id}).addClass("roofpig-count"),this.alg_area.append(count_div),count_div.height(40*this.hscale).width(80*this.scale).css("font-size",24*this.hscale)},Dom}()}.call(this),function(){this.OneChange=function(){function OneChange(action){this.action=action}return OneChange.prototype.update=function(){return this.action()},OneChange.prototype.finish=function(){},OneChange.prototype.finished=function(){return!0},OneChange}()}.call(this),function(){var __indexOf=[].indexOf||function(item){for(var i=0,l=this.length;l>i;i++)if(i in this&&this[i]===item)return i;
-return-1};this.EventHandlers=function(){function EventHandlers(){}var button_keys,key_A,key_C,key_D,key_J,key_K,key_L,key_S,key_X,key_Z,key_down_arrow,key_end,key_home,key_left_arrow,key_question,key_right_arrow,key_space,key_tab,key_up_arrow,rotate_keys,side_for,turn_keys;return EventHandlers.set_focus=function(new_focus){return this.focus!==new_focus?(this.focus&&this.dom.has_focus(!1),this.focus=new_focus,this.camera=this.focus.camera,this.dom=this.focus.dom,this.dom.has_focus(!0)):void 0},EventHandlers.initialize=function(){return $("body").keydown(function(e){return EventHandlers.key_down(e)}),$("body").keyup(function(e){return EventHandlers.key_up(e)}),$(".roofpig").mousedown(function(e){return EventHandlers.mouse_down(e,$(this).data("cube_id"))}),$("body").mousemove(function(e){return EventHandlers.mouse_move(e)}),$("body").mouseup(function(e){return EventHandlers.mouse_end(e)}),$("body").mouseleave(function(e){return EventHandlers.mouse_end(e)}),$(".roofpig").click(function(){var cube;return cube=CubeAnimation.by_id[$(this).data("cube_id")],EventHandlers.set_focus(cube)}),$("button").click(function(e){var button_name,cube_id,_ref;return _ref=$(this).attr("id").split("-"),button_name=_ref[0],cube_id=_ref[1],CubeAnimation.by_id[cube_id].button_click(button_name,e.shiftKey)}),$(".roofpig-help-button").click(function(){var cube_id,_,_ref;return _ref=$(this).attr("id").split("-"),_=_ref[0],cube_id=_ref[1],CubeAnimation.by_id[cube_id].dom.show_help()})},EventHandlers.mouse_down=function(e,clicked_cube_id){return this.dom.remove_help(),clicked_cube_id===this.focus.id?(this.bend_start_x=e.pageX,this.bend_start_y=e.pageY,this.bending=!0):void 0},EventHandlers.mouse_end=function(){return this.focus.add_changer("camera",new OneChange(function(_this){return function(){return _this.camera.bend(0,0)}}(this))),this.bending=!1},EventHandlers.mouse_move=function(e){var dx,dy;return this.bending?(dx=-.02*(e.pageX-this.bend_start_x)/this.dom.scale,dy=-.02*(e.pageY-this.bend_start_y)/this.dom.scale,e.shiftKey&&(dy=0),this.focus.add_changer("camera",new OneChange(function(_this){return function(){return _this.camera.bend(dx,dy)}}(this)))):void 0},EventHandlers.key_down=function(e){var alt,axis,help_toggled,key,new_focus,shift,turns,unhandled,_ref;return help_toggled=this.dom.remove_help(),e.ctrlKey||e.metaKey?!0:(_ref=[e.keyCode,e.shiftKey,e.altKey],key=_ref[0],shift=_ref[1],alt=_ref[2],key===key_tab?(new_focus=shift?this.focus.previous_cube():this.focus.next_cube(),this.set_focus(new_focus)):key===key_end||key===key_right_arrow&&shift?this.focus.add_changer("pieces",new OneChange(function(_this){return function(){return _this.focus.alg.to_end(_this.focus.world3d)}}(this))):__indexOf.call(button_keys,key)>=0?this._fake_click_down(this._button_for(key,shift)):__indexOf.call(rotate_keys,key)>=0?(axis=function(){switch(key){case key_C:case key_Z:return"up";case key_A:case key_D:return"dr";case key_S:case key_X:return"dl"}}(),turns=function(){switch(key){case key_C:case key_A:case key_S:return 1;case key_Z:case key_D:case key_X:return-1}}(),this._rotate(axis,turns)):__indexOf.call(turn_keys,key)>=0?(turns=shift?3:alt?2:1,this._move(""+side_for[key]+turns)):key===key_question?help_toggled||this.focus.dom.show_help():unhandled=!0,unhandled?void 0:(e.preventDefault(),e.stopPropagation()))},EventHandlers._button_for=function(key,shift){switch(key){case key_home:return this.dom.reset;case key_left_arrow:return shift?this.dom.reset:this.dom.prev;case key_right_arrow:return this.dom.next;case key_space:return this.dom.play_or_pause}},EventHandlers.key_up=function(e){var button_key,_ref;return _ref=e.keyCode,button_key=__indexOf.call(button_keys,_ref)>=0,button_key&&this.down_button&&(this._fake_click_up(this.down_button),this.down_button=null),button_key},EventHandlers._fake_click_down=function(button){return button.attr("disabled")?void 0:(this.down_button=button,button.addClass("roofpig-button-fake-active"))},EventHandlers._fake_click_up=function(button){return button.attr("disabled")?void 0:(button.removeClass("roofpig-button-fake-active"),button.click())},EventHandlers._rotate=function(axis_name,turns){var angle_to_turn;return angle_to_turn=-Math.PI/2*turns,this.focus.add_changer("camera",new CameraMovement(this.camera,this.camera.user_dir[axis_name],angle_to_turn,500,!0))},EventHandlers._move=function(code){return this.focus.add_changer("pieces",new Move(code,this.focus.world3d,200).show_do())},key_tab=9,key_space=32,key_end=35,key_home=36,key_left_arrow=37,key_up_arrow=38,key_right_arrow=39,key_down_arrow=40,key_A=65,key_C=67,key_D=68,key_J=74,key_K=75,key_L=76,key_S=83,key_X=88,key_Z=90,key_question=191,button_keys=[key_space,key_home,key_left_arrow,key_right_arrow],rotate_keys=[key_C,key_Z,key_A,key_D,key_S,key_X],turn_keys=[key_J,key_K,key_L],side_for={},side_for[key_J]="U",side_for[key_K]="F",side_for[key_L]="R",EventHandlers}()}.call(this),function(){this.Pieces3D=function(){function Pieces3D(scene,config){this.at={},this.make_stickers(scene,config.hover,config.colors)}return Pieces3D.prototype.on=function(layer){var position,_i,_len,_ref,_results;for(_ref=layer.positions,_results=[],_i=0,_len=_ref.length;_len>_i;_i++)position=_ref[_i],_results.push(this.at[position]);return _results},Pieces3D.prototype.move=function(layer,turns){var positive_turns;return positive_turns=(turns+4)%4,this._track_stickers(layer,positive_turns),this._track_pieces(positive_turns,layer.cycle1,layer.cycle2)},Pieces3D.prototype.state=function(){var piece,result,_i,_len,_ref;for(result="",_ref=["B","BL","BR","D","DB","DBL","DBR","DF","DFL","DFR","DL","DR","F","FL","FR","L","R","U","UB","UBL","UBR","UF","UFL","UFR","UL","UR"],_i=0,_len=_ref.length;_len>_i;_i++)piece=_ref[_i],result+=this[piece].sticker_locations.join("")+" ";return result},Pieces3D.prototype._track_stickers=function(layer,turns){var item,piece,_i,_len,_ref,_results;for(_ref=this.on(layer),_results=[],_i=0,_len=_ref.length;_len>_i;_i++)piece=_ref[_i],_results.push(piece.sticker_locations=function(){var _j,_len1,_ref1,_results1;for(_ref1=piece.sticker_locations,_results1=[],_j=0,_len1=_ref1.length;_len1>_j;_j++)item=_ref1[_j],_results1.push(layer.shift(item,turns));return _results1}());return _results},Pieces3D.prototype._track_pieces=function(turns,cycle1,cycle2){var n,_i,_results;for(_results=[],n=_i=1;turns>=1?turns>=_i:_i>=turns;n=turns>=1?++_i:--_i)this._permute(cycle1),_results.push(this._permute(cycle2));return _results},Pieces3D.prototype._permute=function(p){var _ref;return _ref=[this.at[p[1]],this.at[p[2]],this.at[p[3]],this.at[p[0]]],this.at[p[0]]=_ref[0],this.at[p[1]]=_ref[1],this.at[p[2]]=_ref[2],this.at[p[3]]=_ref[3],_ref},Pieces3D.prototype.make_stickers=function(scene,hover,colors){var piece,side,slice,sticker_look,x_side,y_side,z_side,_i,_len,_ref,_results;for(slice={normal:v3(0,0,0),name:"-"},_ref=[Layer.R,slice,Layer.L],_results=[],_i=0,_len=_ref.length;_len>_i;_i++)x_side=_ref[_i],_results.push(function(){var _j,_len1,_ref1,_results1;for(_ref1=[Layer.F,slice,Layer.B],_results1=[],_j=0,_len1=_ref1.length;_len1>_j;_j++)y_side=_ref1[_j],_results1.push(function(){var _k,_l,_len2,_len3,_ref2,_ref3,_results2;for(_ref2=[Layer.U,slice,Layer.D],_results2=[],_k=0,_len2=_ref2.length;_len2>_k;_k++){for(z_side=_ref2[_k],piece=this._new_piece(x_side,y_side,z_side),_ref3=[x_side,y_side,z_side],_l=0,_len3=_ref3.length;_len3>_l;_l++)side=_ref3[_l],side!==slice&&(sticker_look=colors.to_draw(piece.name,side),this._add_sticker(side,piece,sticker_look),sticker_look.hovers&&hover>1&&this._add_hover_sticker(side,piece,sticker_look,hover),this._add_cubeside(side,piece,colors.of("cube")));this[piece.name]=this.at[piece.name]=piece,_results2.push(scene.add(piece))}return _results2}.call(this));return _results1}.call(this));return _results},Pieces3D.prototype._new_piece=function(x_side,y_side,z_side){var new_piece;return new_piece=new THREE.Object3D,new_piece.name=standardize_name(x_side.name+y_side.name+z_side.name),new_piece.sticker_locations=new_piece.name.split(""),new_piece.middle=v3(2*x_side.normal.x,2*y_side.normal.y,2*z_side.normal.z),new_piece},Pieces3D.prototype._add_sticker=function(side,piece_3d,sticker){var dx,dy,_ref;return _ref=this._offsets(side.normal,.9,!1),dx=_ref[0],dy=_ref[1],piece_3d.add(this._diamond(this._square_center(side,piece_3d.middle,1.0002),dx,dy,sticker.color)),sticker.x_color?this._add_X(side,piece_3d,sticker.x_color,1.0004,!0):void 0},Pieces3D.prototype._add_hover_sticker=function(side,piece_3d,sticker,hover){var dx,dy,_ref;return _ref=this._offsets(side.normal,.98,!0),dx=_ref[0],dy=_ref[1],piece_3d.add(this._diamond(this._square_center(side,piece_3d.middle,hover),dx,dy,sticker.color)),sticker.x_color?this._add_X(side,piece_3d,sticker.x_color,hover-2e-4,!1):void 0},Pieces3D.prototype._add_cubeside=function(side,piece_3d,color){var dx,dy,_ref;return _ref=this._offsets(side.normal,1,!0),dx=_ref[0],dy=_ref[1],piece_3d.add(this._diamond(this._square_center(side,piece_3d.middle,1),dx,dy,color))},Pieces3D.prototype._add_X=function(side,piece_3d,color,distance,reversed){var center,dx,dy,_ref;return _ref=this._offsets(side.normal,.54,reversed),dx=_ref[0],dy=_ref[1],center=this._square_center(side,piece_3d.middle,distance),piece_3d.add(this._rect(center,dx,v3_x(dy,.14),color)),piece_3d.add(this._rect(center,v3_x(dx,.14),dy,color))},Pieces3D.prototype._square_center=function(side,piece_center,distance){return v3_add(piece_center,v3_x(side.normal,distance))},Pieces3D.prototype._rect=function(center,d1,d2,color){return this._diamond(center,v3_add(d1,d2),v3_sub(d1,d2),color)},Pieces3D.prototype._diamond=function(center,d1,d2,color){var geo;return geo=new THREE.Geometry,geo.vertices.push(v3_add(center,d1),v3_add(center,d2),v3_sub(center,d1),v3_sub(center,d2)),geo.faces.push(new THREE.Face3(0,1,2),new THREE.Face3(0,2,3)),geo.computeFaceNormals(),geo.computeBoundingSphere(),new THREE.Mesh(geo,new THREE.MeshBasicMaterial({color:color,overdraw:.8}))},Pieces3D.prototype._offsets=function(axis1,sticker_size,reversed){var axis2,axis3,dx,dy,flip;return axis2=v3(axis1.y,axis1.z,axis1.x),axis3=v3(axis1.z,axis1.x,axis1.y),flip=(axis1.y+axis1.z+axis1.x)*(reversed?-1:1),dx=v3_add(axis2,axis3).multiplyScalar(sticker_size*flip),dy=v3_sub(axis2,axis3).multiplyScalar(sticker_size),[dx,dy]},Pieces3D}()}.call(this),function(){var __hasProp={}.hasOwnProperty;this.CubeAnimation=function(){function CubeAnimation(roofpig_div,webgl_works,canvas_works){return canvas_works?(this.id=CubeAnimation.last_id+=1,CubeAnimation.by_id[this.id]=this,this.config=new Config(roofpig_div.data("config")),this.config.flag("canvas")||!webgl_works||CubeAnimation.webgl_cubes>=16?this.renderer=new THREE.CanvasRenderer({alpha:!0}):(CubeAnimation.webgl_cubes+=1,this.renderer=new THREE.WebGLRenderer({antialias:!0,alpha:!0})),this.dom=new Dom(this.id,roofpig_div,this.renderer),this.scene=new THREE.Scene,this.camera=new Camera(this.config.hover,this.config.pov),this.world3d={pieces:new Pieces3D(this.scene,this.config),camera:this.camera},this.config.setup&&new Alg(this.config.setup,this.world3d).to_end(),""!==this.config.alg&&(this.dom.add_alg_area(this.config.flag("showalg")),this.alg=new Alg(this.config.alg,this.world3d,this.config.algdisplay,this.config.speed,this.dom),this.alg.mix()),1===this.id&&EventHandlers.set_focus(this),this.changers={},void this.animate(!0)):(roofpig_div.html("Your browser does not support <a href='http://khronos.org/webgl/wiki/Getting_a_WebGL_Implementation'>WebGL</a>.<p/> Find out how to get it <a href='http://get.webgl.org/'>here</a>."),void roofpig_div.css({background:"#f66"}))}return CubeAnimation.last_id=0,CubeAnimation.by_id=[],CubeAnimation.webgl_cubes=0,CubeAnimation.prototype.next_cube=function(){var next_id;return next_id=this.id%CubeAnimation.last_id+1,CubeAnimation.by_id[next_id]},CubeAnimation.prototype.previous_cube=function(){var prev_id;return prev_id=(this.id+CubeAnimation.last_id-2)%CubeAnimation.last_id+1,CubeAnimation.by_id[prev_id]},CubeAnimation.prototype.animate=function(first_time){var any_change,category,changer,now,_ref;null==first_time&&(first_time=!1),now=(new Date).getTime(),_ref=this.changers;for(category in _ref)__hasProp.call(_ref,category)&&(changer=_ref[category],changer&&(changer.update(now),changer.finished()&&(this.changers[category]=null),any_change=!0));return(any_change||first_time)&&this.renderer.render(this.scene,this.camera.cam),requestAnimationFrame(function(_this){return function(){return _this.animate()}}(this))},CubeAnimation.prototype.add_changer=function(category,changer){return this.changers[category]&&this.changers[category].finish(),this.changers[category]=changer},CubeAnimation.prototype.button_click=function(name,shift){var changer;switch(name){case"play":changer=shift?new OneChange(function(_this){return function(){return _this.alg.to_end(_this.world3d)}}(this)):this.alg.play(this.world3d);break;case"pause":this.alg.stop();break;case"next":this.alg.at_end()||(changer=this.alg.next_move().show_do(this.world3d));break;case"prev":this.alg.at_start()||(changer=this.alg.prev_move().show_undo(this.world3d));break;case"reset":changer=new OneChange(function(_this){return function(){return _this.alg.to_start(_this.world3d)}}(this))}return changer?this.add_changer("pieces",changer):void 0},CubeAnimation}()}.call(this),function(){$(document).ready(function(){var canvas_browser,roofpig_div,webgl_browser,_i,_len,_ref;for(console.log("Roofpig version 1.0 (2014-06-28 16:10). Expecting jQuery 1.11.1 and Three.js 67."),console.log("jQuery version",$.fn.jquery),$("head").append(Css.CODE),webgl_browser=function(){var e;try{return!!window.WebGLRenderingContext&&!!document.createElement("canvas").getContext("experimental-webgl")}catch(_error){return e=_error,!1}}(),canvas_browser=!!window.CanvasRenderingContext2D,canvas_browser?webgl_browser||log_error("No WebGL support in this browser. Falling back on regular Canvas."):log_error("No Canvas support in this browser. Giving up."),_ref=$(".roofpig"),_i=0,_len=_ref.length;_len>_i;_i++)roofpig_div=_ref[_i],new CubeAnimation($(roofpig_div),webgl_browser,canvas_browser);return EventHandlers.initialize()})}.call(this);
+(function () {
+    var __indexOf = [].indexOf || function (item) {
+        for (var i = 0, l = this.length; l > i; i++)if (i in this && this[i] === item)return i;
+        return-1
+    };
+    this.v3 = function (x, y, z) {
+        return new THREE.Vector3(x, y, z)
+    }, this.v3_add = function (v1, v2) {
+        return v1.clone().add(v2)
+    }, this.v3_sub = function (v1, v2) {
+        return v1.clone().sub(v2)
+    }, this.v3_x = function (v, factor) {
+        return v.clone().multiplyScalar(factor)
+    }, this.standardize_name = function (name) {
+        var ordered_side, result, sides, _i, _len, _ref;
+        for (sides = [name[0], name[1], name[2]], result = "", _ref = ["U", "D", "F", "B", "R", "L"], _i = 0, _len = _ref.length; _len > _i; _i++)ordered_side = _ref[_i], __indexOf.call(sides, ordered_side) >= 0 && (result += ordered_side);
+        return result
+    }, this.side_name = function (side) {
+        return side ? side.name || side : ""
+    }, this.log_error = function (text) {
+        return console.log("RoofPig error: " + text)
+    }
+}).call(this), function () {
+    this.Layer = function () {
+        function Layer(name, normal, cycle1, cycle2, uncycled, sticker_cycle) {
+            this.name = name, this.normal = normal, this.cycle1 = cycle1, this.cycle2 = cycle2, this.sticker_cycle = sticker_cycle, this.positions = this.cycle1.concat(this.cycle2, uncycled)
+        }
+
+        var all, sides;
+        return Layer.by_name = function (name) {
+            return all[name]
+        }, Layer.side_by_name = function (name) {
+            return sides[name]
+        }, Layer.R = new Layer("R", v3(-1, 0, 0), ["UFR", "DFR", "DBR", "UBR"], ["UR", "FR", "DR", "BR"], ["R"], {B: "D", D: "F", F: "U", U: "B", L: "L", R: "R"}), Layer.L = new Layer("L", v3(1, 0, 0), ["UBL", "DBL", "DFL", "UFL"], ["BL", "DL", "FL", "UL"], ["L"], {B: "U", U: "F", F: "D", D: "B", L: "L", R: "R"}), Layer.F = new Layer("F", v3(0, 1, 0), ["DFL", "DFR", "UFR", "UFL"], ["FL", "DF", "FR", "UF"], ["F"], {U: "R", R: "D", D: "L", L: "U", F: "F", B: "B"}), Layer.B = new Layer("B", v3(0, -1, 0), ["UBL", "UBR", "DBR", "DBL"], ["UB", "BR", "DB", "BL"], ["B"], {U: "L", L: "D", D: "R", R: "U", F: "F", B: "B"}), Layer.U = new Layer("U", v3(0, 0, 1), ["UBR", "UBL", "UFL", "UFR"], ["UR", "UB", "UL", "UF"], ["U"], {F: "R", R: "B", B: "L", L: "F", U: "U", D: "D"}), Layer.D = new Layer("D", v3(0, 0, -1), ["DFR", "DFL", "DBL", "DBR"], ["DF", "DL", "DB", "DR"], ["D"], {F: "L", L: "B", B: "R", R: "F", U: "U", D: "D"}), Layer.M = new Layer("M", Layer.L.normal, ["UF", "UB", "DB", "DF"], ["U", "B", "D", "F"], [], Layer.L.sticker_cycle), Layer.E = new Layer("E", Layer.D.normal, ["BL", "BR", "FR", "FL"], ["L", "B", "R", "F"], [], Layer.D.sticker_cycle), Layer.S = new Layer("S", Layer.F.normal, ["DL", "DR", "UR", "UL"], ["L", "D", "R", "U"], [], Layer.F.sticker_cycle), Layer.prototype.shift = function (side_name, turns) {
+            var n, result, _i;
+            if (!this.sticker_cycle[side_name])return null;
+            if (1 > turns)throw new Error("Invalid turn number: '" + turns + "'");
+            for (result = side_name, n = _i = 1; turns >= 1 ? turns >= _i : _i >= turns; n = turns >= 1 ? ++_i : --_i)result = this.sticker_cycle[result];
+            return result
+        }, all = {R: Layer.R, L: Layer.L, F: Layer.F, B: Layer.B, D: Layer.D, U: Layer.U, M: Layer.M, E: Layer.E, S: Layer.S}, sides = {R: Layer.R, L: Layer.L, F: Layer.F, B: Layer.B, D: Layer.D, U: Layer.U}, Layer
+    }()
+}.call(this), function () {
+    this.TimedChanger = function () {
+        function TimedChanger(duration) {
+            this.duration = duration, this.start_time = (new Date).getTime(), this.last_time = this.start_time
+        }
+
+        return TimedChanger.prototype.update = function (now) {
+            return this._finished ? void 0 : now > this.start_time + this.duration ? this.finish() : this._make_change(now)
+        }, TimedChanger.prototype.finish = function () {
+            return this.finished() ? void 0 : (this._make_change(this.start_time + this.duration), this._finished = !0)
+        }, TimedChanger.prototype.finished = function () {
+            return this._finished
+        }, TimedChanger.prototype._make_change = function (to_time) {
+            return this.do_change(this._ease(to_time) - this._ease(this.last_time)), this.last_time = to_time
+        }, TimedChanger.prototype._ease = function (a_time) {
+            var x;
+            return x = (a_time - this.start_time) / this.duration, x * x * (2 - x * x)
+        }, TimedChanger
+    }()
+}.call(this), function () {
+    var __hasProp = {}.hasOwnProperty, __extends = function (child, parent) {
+        function ctor() {
+            this.constructor = child
+        }
+
+        for (var key in parent)__hasProp.call(parent, key) && (child[key] = parent[key]);
+        return ctor.prototype = parent.prototype, child.prototype = new ctor, child.__super__ = parent.prototype, child
+    };
+    this.CameraMovement = function (_super) {
+        function CameraMovement(camera, axis, angle_to_turn, turn_time, animate) {
+            this.camera = camera, this.axis = axis, this.angle_to_turn = angle_to_turn, CameraMovement.__super__.constructor.call(this, turn_time), animate || this.finish()
+        }
+
+        return __extends(CameraMovement, _super), CameraMovement.prototype.do_change = function (completion_diff) {
+            return this.camera.rotate(this.axis, completion_diff * this.angle_to_turn)
+        }, CameraMovement
+    }(TimedChanger)
+}.call(this), function () {
+    var __hasProp = {}.hasOwnProperty, __extends = function (child, parent) {
+        function ctor() {
+            this.constructor = child
+        }
+
+        for (var key in parent)__hasProp.call(parent, key) && (child[key] = parent[key]);
+        return ctor.prototype = parent.prototype, child.prototype = new ctor, child.__super__ = parent.prototype, child
+    };
+    this.MoveExecution = function (_super) {
+        function MoveExecution(pieces, axis, angle_to_turn, turn_time, animate) {
+            this.pieces = pieces, this.axis = axis, this.angle_to_turn = angle_to_turn, MoveExecution.__super__.constructor.call(this, turn_time), animate || this.finish()
+        }
+
+        return __extends(MoveExecution, _super), MoveExecution.prototype.do_change = function (completion_diff) {
+            var piece, _i, _len, _ref, _results;
+            for (_ref = this.pieces, _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)piece = _ref[_i], _results.push(this._rotateAroundWorldAxis(piece, completion_diff * this.angle_to_turn));
+            return _results
+        }, MoveExecution.prototype._rotateAroundWorldAxis = function (object, radians) {
+            var rotWorldMatrix;
+            return rotWorldMatrix = new THREE.Matrix4, rotWorldMatrix.makeRotationAxis(this.axis, radians), rotWorldMatrix.multiply(object.matrix), object.matrix = rotWorldMatrix, object.rotation.setFromRotationMatrix(object.matrix)
+        }, MoveExecution
+    }(TimedChanger)
+}.call(this), function () {
+    this.Move = function () {
+        function Move(code, world3d, speed) {
+            var _ref;
+            this.world3d = world3d, this.speed = null != speed ? speed : 400, _ref = Move._parse_code(code), this.layer = _ref[0], this.turns = _ref[1], this.is_rotation = _ref[2], this.turn_time = this.speed / 2 * (1 + Math.abs(this.turns))
+        }
+
+        return Move._parse_code = function (code) {
+            var is_rotation, layer, turns, _ref;
+            if (turns = Move.parse_turns(code.substring(1)), is_rotation = ">" === (_ref = code.substring(1)) || ">>" === _ref || "<" === _ref || "<<" === _ref, layer = Layer.by_name(code[0]), !layer || !turns)throw new Error("Invalid Move code '" + code + "'");
+            return[layer, turns, is_rotation]
+        }, Move.parse_turns = function (tcode) {
+            switch (tcode) {
+                case"1":
+                case"":
+                case">":
+                    return 1;
+                case"2":
+                case"²":
+                case">>":
+                    return 2;
+                case"3":
+                case"'":
+                case"<":
+                    return-1;
+                case"Z":
+                case"2'":
+                case"<<":
+                    return-2
+            }
+        }, Move.prototype["do"] = function () {
+            return this._do(this.turns, !1)
+        }, Move.prototype.undo = function () {
+            return this._do(-this.turns, !1)
+        }, Move.prototype.mix = function () {
+            return this.is_rotation ? void 0 : this.undo()
+        }, Move.prototype.track_drift = function (side_drift) {
+            var cycle, i, location, side, _i, _len, _ref, _results;
+            for (_ref = [this.layer.cycle1, this.layer.cycle2], _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)cycle = _ref[_i], 1 === cycle[0].length && _results.push(function () {
+                var _results1;
+                _results1 = [];
+                for (side in side_drift)location = side_drift[side], _results1.push(function () {
+                    var _j, _results2;
+                    for (_results2 = [], i = _j = 0; 3 >= _j; i = ++_j)_results2.push(location === cycle[i] ? side_drift[side] = cycle[(i + this.turns + 4) % 4] : void 0);
+                    return _results2
+                }.call(this));
+                return _results1
+            }.call(this));
+            return _results
+        }, Move.prototype.show_do = function () {
+            return this._do(this.turns, !0)
+        }, Move.prototype.show_undo = function () {
+            return this._do(-this.turns, !0)
+        }, Move.prototype._do = function (do_turns, animate) {
+            return this.is_rotation ? new CameraMovement(this.world3d.camera, this.layer.normal, do_turns * Math.PI / 2, this.turn_time, animate) : (this.world3d.pieces.move(this.layer, do_turns), new MoveExecution(this.world3d.pieces.on(this.layer), this.layer.normal, do_turns * -Math.PI / 2, this.turn_time, animate))
+        }, Move.prototype.count = function (count_rotations) {
+            return count_rotations || !this.is_rotation ? 1 : 0
+        }, Move.prototype.to_s = function () {
+            var turn_codes;
+            return turn_codes = {"true": {1: ">", 2: ">>", "-1": "<", "-2": "<<"}, "false": {1: "", 2: "2", "-1": "'", "-2": "Z"}}, "" + this.layer.name + turn_codes[this.is_rotation][this.turns]
+        }, Move.displayify = function (move_text, algdisplay) {
+            var result;
+            return result = move_text.replace("Z", algdisplay.Zcode), algdisplay.fancy2s && (result = result.replace("2", "²")), result
+        }, Move.prototype.display_text = function (algdisplay) {
+            return algdisplay.rotations || !this.is_rotation ? Move.displayify(this.to_s(), algdisplay) : ""
+        }, Move
+    }()
+}.call(this), function () {
+    this.ConcurrentChangers = function () {
+        function ConcurrentChangers(sub_changers) {
+            this.sub_changers = sub_changers
+        }
+
+        return ConcurrentChangers.prototype.update = function (now) {
+            var changer, _i, _len, _ref, _results;
+            for (_ref = this.sub_changers, _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)changer = _ref[_i], _results.push(changer.update(now));
+            return _results
+        }, ConcurrentChangers.prototype.finish = function () {
+            var changer, _i, _len, _ref, _results;
+            for (_ref = this.sub_changers, _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)changer = _ref[_i], _results.push(changer.finish());
+            return _results
+        }, ConcurrentChangers.prototype.finished = function () {
+            var changer, _i, _len, _ref;
+            for (_ref = this.sub_changers, _i = 0, _len = _ref.length; _len > _i; _i++)if (changer = _ref[_i], !changer.finished())return!1;
+            return!0
+        }, ConcurrentChangers
+    }()
+}.call(this), function () {
+    this.CompositeMove = function () {
+        function CompositeMove(move_codes, world3d, speed, official_text) {
+            var code;
+            this.official_text = null != official_text ? official_text : null, this.moves = function () {
+                var _i, _len, _ref, _results;
+                for (_ref = move_codes.split("+"), _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)code = _ref[_i], _results.push(new Move(code, world3d, speed));
+                return _results
+            }()
+        }
+
+        return CompositeMove.prototype["do"] = function () {
+            return new ConcurrentChangers(this.moves.map(function (move) {
+                return move["do"]()
+            }))
+        }, CompositeMove.prototype.undo = function () {
+            return new ConcurrentChangers(this.moves.map(function (move) {
+                return move.undo()
+            }))
+        }, CompositeMove.prototype.mix = function () {
+            return new ConcurrentChangers(this.moves.map(function (move) {
+                return move.mix()
+            }))
+        }, CompositeMove.prototype.show_do = function () {
+            return new ConcurrentChangers(this.moves.map(function (move) {
+                return move.show_do()
+            }))
+        }, CompositeMove.prototype.show_undo = function () {
+            return new ConcurrentChangers(this.moves.map(function (move) {
+                return move.show_undo()
+            }))
+        }, CompositeMove.prototype.track_drift = function (side_drift) {
+            var move, _i, _len, _ref, _results;
+            for (_ref = this.moves, _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)move = _ref[_i], _results.push(move.track_drift(side_drift));
+            return _results
+        }, CompositeMove.prototype.count = function (count_rotations) {
+            var move, result, _i, _len, _ref;
+            if (this.official_text)return 1;
+            for (result = 0, _ref = this.moves, _i = 0, _len = _ref.length; _len > _i; _i++)move = _ref[_i], result += move.count(count_rotations);
+            return result
+        }, CompositeMove.prototype.to_s = function () {
+            return"(" + this.moves.map(function (move) {
+                return move.to_s()
+            }).join(" ") + ")"
+        }, CompositeMove.prototype.display_text = function (algdisplay) {
+            var display_texts, text;
+            return this.official_text ? Move.displayify(this.official_text, algdisplay) : (display_texts = this.moves.map(function (move) {
+                return move.display_text(algdisplay)
+            }), function () {
+                var _i, _len, _results;
+                for (_results = [], _i = 0, _len = display_texts.length; _len > _i; _i++)text = display_texts[_i], text && _results.push(text);
+                return _results
+            }().join("+"))
+        }, CompositeMove
+    }()
+}.call(this), function () {
+    this.AlgAnimation = function () {
+        function AlgAnimation(alg) {
+            this.alg = alg, this._next_alg_move()
+        }
+
+        return AlgAnimation.prototype.update = function (now) {
+            return this._finished ? void 0 : (this.move_changer.finished() && this._next_alg_move(), this.move_changer.update(now))
+        }, AlgAnimation.prototype.finish = function () {
+        }, AlgAnimation.prototype.finished = function () {
+            return this._finished
+        }, AlgAnimation.prototype._next_alg_move = function () {
+            return this.alg.at_end() || !this.alg.playing ? this._finished = !0 : this.move_changer = this.alg.next_move().show_do()
+        }, AlgAnimation
+    }()
+}.call(this), function () {
+    this.Alg = function () {
+        function Alg(move_codes, world3d, algdisplay, speed, dom) {
+            var code, _i, _len, _ref;
+            if (this.move_codes = move_codes, this.world3d = world3d, this.algdisplay = algdisplay, this.speed = speed, this.dom = dom, !this.move_codes || "" === this.move_codes)throw new Error("Invalid alg: '" + this.move_codes + "'");
+            for (this.moves = [], _ref = this.move_codes.split(" "), _i = 0, _len = _ref.length; _len > _i; _i++)code = _ref[_i], code.length > 0 && this.moves.push(this._make_move(code));
+            this.next = 0, this.playing = !1, this._update_dom("first time")
+        }
+
+        var turn_codes;
+        return Alg.prototype.next_move = function () {
+            return this.at_end() ? void 0 : (this.next += 1, this.at_end() && (this.playing = !1), this._update_dom(), this.moves[this.next - 1])
+        }, Alg.prototype.prev_move = function () {
+            return this.at_start() ? void 0 : (this.next -= 1, this._update_dom(), this.moves[this.next])
+        }, Alg.prototype.play = function () {
+            return this.playing = !0, this._update_dom(), new AlgAnimation(this)
+        }, Alg.prototype.stop = function () {
+            return this.playing = !1, this._update_dom()
+        }, Alg.prototype.to_end = function () {
+            var _results;
+            for (_results = []; !this.at_end();)_results.push(this.next_move()["do"]());
+            return _results
+        }, Alg.prototype.to_start = function () {
+            var _results;
+            for (_results = []; !this.at_start();)_results.push(this.prev_move().undo());
+            return _results
+        }, Alg.prototype.at_start = function () {
+            return 0 === this.next
+        }, Alg.prototype.at_end = function () {
+            return this.next === this.moves.length
+        }, Alg.prototype.mix = function () {
+            var _results;
+            for (this.next = this.moves.length, _results = []; !this.at_start();)_results.push(this.prev_move().mix());
+            return _results
+        }, Alg.prototype.to_s = function () {
+            return this.moves.map(function (move) {
+                return move.to_s()
+            }).join(" ")
+        }, Alg.prototype.display_text = function () {
+            var active, future, i, move, past, text, _i, _len, _ref;
+            for (active = past = [], future = [], _ref = this.moves, i = _i = 0, _len = _ref.length; _len > _i; i = ++_i)move = _ref[i], this.next === i && (active = future), text = move.display_text(this.algdisplay), text && active.push(text);
+            return{past: past.join(" "), future: future.join(" ")}
+        }, turn_codes = {"-2": ["Z", "2"], "-1": ["'", ""], 1: ["", "'"], 2: ["2", "Z"]}, Alg.prototype._make_move = function (code) {
+            var moves, t1, t2, _ref, _ref1, _ref2, _ref3;
+            return code.indexOf("+") > -1 ? new CompositeMove(code, this.world3d, this.speed) : "x" === (_ref = code[0]) || "y" === _ref || "z" === _ref ? (_ref1 = turn_codes[Move.parse_turns(code.substring(1))], t1 = _ref1[0], t2 = _ref1[1], moves = function () {
+                switch (code[0]) {
+                    case"x":
+                        return"R" + t1 + "+M" + t2 + "+L" + t2;
+                    case"y":
+                        return"U" + t1 + "+E" + t2 + "+D" + t2;
+                    case"z":
+                        return"F" + t1 + "+S" + t1 + "+B" + t2
+                }
+            }(), new CompositeMove(moves, this.world3d, this.speed, code)) : "w" !== code[1] || "U" !== (_ref2 = code[0]) && "D" !== _ref2 && "L" !== _ref2 && "R" !== _ref2 && "F" !== _ref2 && "B" !== _ref2 ? new Move(code, this.world3d, this.speed) : (_ref3 = turn_codes[Move.parse_turns(code.substring(2))], t1 = _ref3[0], t2 = _ref3[1], moves = function () {
+                switch (code[0]) {
+                    case"R":
+                        return"R" + t1 + "+M" + t2;
+                    case"L":
+                        return"L" + t1 + "+M" + t1;
+                    case"U":
+                        return"U" + t1 + "+E" + t2;
+                    case"D":
+                        return"D" + t1 + "+E" + t1;
+                    case"F":
+                        return"F" + t1 + "+S" + t1;
+                    case"B":
+                        return"B" + t1 + "+S" + t2
+                }
+            }(), new CompositeMove(moves, this.world3d, this.speed, code))
+        }, Alg.prototype.side_drift = function () {
+            var result;
+            for (result = {U: "U", D: "D", L: "L", R: "R", F: "F", B: "B"}, this.next = this.moves.length; !this.at_start();)this.prev_move().track_drift(result);
+            return result
+        }, Alg.prototype._update_dom = function (time) {
+            return null == time && (time = "later"), this.dom ? ("first time" === time && this.dom.init_alg_text(this.display_text().future), this.dom.alg_changed(this.playing, this.at_start(), this.at_end(), this._count_text(), this.display_text())) : void 0
+        }, Alg.prototype._count_text = function () {
+            var count, current, i, move, total, _i, _len, _ref;
+            for (total = current = 0, _ref = this.moves, i = _i = 0, _len = _ref.length; _len > _i; i = ++_i)move = _ref[i], count = move.count(this.algdisplay.rotations), this.next > i && (current += count), total += count;
+            return"" + current + "/" + total
+        }, Alg
+    }()
+}.call(this), function () {
+    this.Camera = function () {
+        function Camera(hover, pov_code) {
+            var pov;
+            this.cam = new THREE.PerspectiveCamera(this._view_angle(hover, DISTANCE), 1, 1, 100), pov = Camera._POVs[pov_code], pov || (pov = Camera._POVs.Ufr, log_error("Invalid POV '" + this.pov_code + "'. Using Ufr")), this.cam.position.copy(pov.pos), this.cam.up.copy(pov.up), this.user_dir = {dr: pov.xn.clone(), dl: pov.yn.clone(), up: pov.zn.clone()}, this._cam_moved()
+        }
+
+        var DISTANCE;
+        return DISTANCE = 25, Camera.prototype.rotate = function (axis, angle) {
+            var v, _i, _len, _ref;
+            for (_ref = [this.cam.position, this.cam.up, this.user_dir.dl, this.user_dir.dr, this.user_dir.up], _i = 0, _len = _ref.length; _len > _i; _i++)v = _ref[_i], v.applyAxisAngle(axis, angle);
+            return this._cam_moved()
+        }, Camera.prototype.bend = function (dx, dy) {
+            var axis, v, v1, v2, _i, _len, _ref;
+            for (v1 = v3_x(this.user_dir.up, dx), v2 = v3_sub(this.user_dir.dr, this.user_dir.dl).normalize().multiplyScalar(dy), axis = v3_add(v1, v2).normalize(), this.cam.position = this.unbent_position.clone(), this.cam.up = this.unbent_up.clone(), _ref = [this.cam.position, this.cam.up], _i = 0, _len = _ref.length; _len > _i; _i++)v = _ref[_i], v.applyAxisAngle(axis, Math.sqrt(dx * dx + dy * dy));
+            return this.cam.lookAt(v3(0, 0, 0))
+        }, Camera.prototype._view_angle = function (hover, cam_pos) {
+            var adjustment_factor, distance, max_cube_size;
+            return max_cube_size = 2 * Math.sqrt(hover * hover + 4 * hover + 13), distance = Math.sqrt(3 * cam_pos * cam_pos) - 2, adjustment_factor = 1.015 + .13 * (5 - hover) / 4, 2 * adjustment_factor * Math.atan(max_cube_size / (2 * distance)) * (180 / Math.PI)
+        }, Camera.prototype._cam_moved = function () {
+            return this.cam.lookAt(v3(0, 0, 0)), this.unbent_up = this.cam.up.clone(), this.unbent_position = this.cam.position.clone()
+        }, Camera._flip = function (pov, parity) {
+            var _ref;
+            return parity > 0 && (_ref = [pov.yn, pov.xn], pov.xn = _ref[0], pov.yn = _ref[1]), pov
+        }, Camera._set_perms = function (povs, a, b, c, value) {
+            return povs[a + b + c] = povs[a + c + b] = povs[b + a + c] = povs[b + c + a] = povs[c + a + b] = povs[c + b + a] = value
+        }, Camera._POVs = function () {
+            var parity, pos, result, x, xl, xn, xu, y, yl, yn, yu, z, zl, zn, zu, _i, _j, _k, _len, _len1, _len2, _ref, _ref1, _ref2, _ref3, _ref4, _ref5;
+            for (result = {}, _ref = [Layer.U, Layer.D], _i = 0, _len = _ref.length; _len > _i; _i++)for (z = _ref[_i], _ref1 = [z.name, z.name.toLowerCase(), z.normal.clone()], zu = _ref1[0], zl = _ref1[1], zn = _ref1[2], _ref2 = [Layer.F, Layer.B], _j = 0, _len1 = _ref2.length; _len1 > _j; _j++)for (y = _ref2[_j], _ref3 = [y.name, y.name.toLowerCase(), y.normal.clone()], yu = _ref3[0], yl = _ref3[1], yn = _ref3[2], _ref4 = [Layer.R, Layer.L], _k = 0, _len2 = _ref4.length; _len2 > _k; _k++)x = _ref4[_k], _ref5 = [x.name, x.name.toLowerCase(), x.normal.clone()], xu = _ref5[0], xl = _ref5[1], xn = _ref5[2], pos = v3(xn.x, yn.y, zn.z).multiplyScalar(DISTANCE), parity = xn.x * yn.y * zn.z, Camera._set_perms(result, zu, yl, xl, Camera._flip({pos: pos, up: zn, zn: zn, yn: yn, xn: xn}, parity)), Camera._set_perms(result, zl, yu, xl, Camera._flip({pos: pos, up: yn, zn: yn, yn: xn, xn: zn}, parity)), Camera._set_perms(result, zl, yl, xu, Camera._flip({pos: pos, up: xn, zn: xn, yn: zn, xn: yn}, parity));
+            return result
+        }(), Camera
+    }()
+}.call(this), function () {
+    this.Cubexp = function () {
+        function Cubexp(cubexp_string) {
+            var excluded, exp, expression, piece, side, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _len5, _len6, _len7, _m, _n, _o, _p, _ref, _ref1, _ref2;
+            for (null == cubexp_string && (cubexp_string = ""), this.matches = {}, _i = 0, _len = PIECE_NAMES.length; _len > _i; _i++)piece = PIECE_NAMES[_i], this.matches[piece] = {};
+            for (_ref = cubexp_string.split(" "), _j = 0, _len1 = _ref.length; _len1 > _j; _j++)switch (expression = _ref[_j], exp = this._parse(expression), exp.type) {
+                case"XYZ":
+                    this._add_match(exp.piece, exp.type_filter, exp.sides);
+                    break;
+                case"X-":
+                    for (_k = 0, _len2 = PIECE_NAMES.length; _len2 > _k; _k++) {
+                        for (piece = PIECE_NAMES[_k], excluded = !1, _ref1 = exp.piece.split(""), _l = 0, _len3 = _ref1.length; _len3 > _l; _l++)side = _ref1[_l], excluded || (excluded = piece.indexOf(side) > -1);
+                        excluded || this._add_match(piece, exp.type_filter)
+                    }
+                    break;
+                case"X*":
+                    for (_m = 0, _len4 = PIECE_NAMES.length; _len4 > _m; _m++)for (piece = PIECE_NAMES[_m], _ref2 = exp.piece.split(""), _n = 0, _len5 = _ref2.length; _len5 > _n; _n++)side = _ref2[_n], piece.indexOf(side) > -1 && this._add_match(piece, exp.type_filter);
+                    break;
+                case"*":
+                    for (_o = 0, _len6 = PIECE_NAMES.length; _len6 > _o; _o++)piece = PIECE_NAMES[_o], this._add_match(piece, exp.type_filter);
+                    break;
+                case"x":
+                    for (_p = 0, _len7 = PIECE_NAMES.length; _len7 > _p; _p++)piece = PIECE_NAMES[_p], piece.indexOf(exp.piece[0]) > -1 && this._add_match(piece, exp.type_filter, exp.piece);
+                    break;
+                default:
+                    log_error("Ignored unrecognized Cubexp '" + expression + "'.")
+            }
+        }
+
+        var PIECE_NAMES;
+        return PIECE_NAMES = ["B", "BL", "BR", "D", "DB", "DBL", "DBR", "DF", "DFL", "DFR", "DL", "DR", "F", "FL", "FR", "L", "R", "U", "UB", "UBL", "UBR", "UF", "UFL", "UFR", "UL", "UR"], Cubexp.prototype.matches_sticker = function (piece, side) {
+            return null != this.matches[standardize_name(piece)][side_name(side)]
+        }, Cubexp.prototype.selected_pieces = function () {
+            var code, piece, result, selected, selections, side, _i, _len, _ref, _ref1;
+            result = [], _ref = this.matches;
+            for (piece in _ref) {
+                for (selections = _ref[piece], code = "", selected = !1, _ref1 = piece.split(""), _i = 0, _len = _ref1.length; _len > _i; _i++)side = _ref1[_i], selected || (selected = selections[side]), code += selections[side] ? side : side.toLowerCase();
+                selected && result.push(code)
+            }
+            return result
+        }, Cubexp.prototype._add_match = function (piece, type_filter, sides) {
+            var piece_type, side, _i, _len, _ref, _results;
+            if (null == sides && (sides = piece), piece_type = "mec"[piece.length - 1], !type_filter || type_filter.indexOf(piece_type) > -1) {
+                for (_ref = sides.split(""), _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)side = _ref[_i], _results.push(this.matches[piece][side] = !0);
+                return _results
+            }
+        }, Cubexp.prototype._parse = function (expression) {
+            var exp, last_char, result, _ref;
+            switch (result = {}, _ref = expression.split("/"), exp = _ref[0], result.type_filter = _ref[1], result.piece = standardize_name(exp.toUpperCase()), last_char = exp[exp.length - 1]) {
+                case"*":
+                    result.type = "*" === exp ? "*" : "X*";
+                    break;
+                case"-":
+                    result.type = "X-";
+                    break;
+                default:
+                    exp === result.piece.toLowerCase() ? result.type = "x" : (result.type = "XYZ", result.sides = standardize_name(exp))
+            }
+            return result
+        }, Cubexp
+    }()
+}.call(this), function () {
+    this.Tweaks = function () {
+        function Tweaks(expressions) {
+            var expression, i, piece, piece_exp, side, what, where, _i, _j, _k, _l, _len, _len1, _len2, _len3, _ref, _ref1, _ref2, _ref3, _ref4;
+            if (this.tweaks = {}, expressions)for (_ref = expressions.split(" "), _i = 0, _len = _ref.length; _len > _i; _i++)if (expression = _ref[_i], _ref1 = expression.split(":"), what = _ref1[0], where = _ref1[1], where)if (1 === what.length)for (_ref2 = new Cubexp(where).selected_pieces(), _j = 0, _len1 = _ref2.length; _len1 > _j; _j++)for (piece_exp = _ref2[_j], _ref3 = piece_exp.split(""), _k = 0, _len2 = _ref3.length; _len2 > _k; _k++)side = _ref3[_k], this._add(piece_exp.toUpperCase(), side, what); else for (piece = standardize_name(where.toUpperCase()), _ref4 = where.split(""), i = _l = 0, _len3 = _ref4.length; _len3 > _l; i = ++_l)side = _ref4[i], this._add(piece, side, what[i])
+        }
+
+        return Tweaks.prototype.for_sticker = function (piece, side) {
+            var match;
+            return match = this.tweaks[standardize_name(piece)] || {}, match[side_name(side)] || []
+        }, Tweaks.prototype._add = function (piece, side, what) {
+            var _base, _base1;
+            return Layer.side_by_name(side) ? (null == (_base = this.tweaks)[piece] && (_base[piece] = {}), null == (_base1 = this.tweaks[piece])[side] && (_base1[side] = []), this.tweaks[piece][side].push(what)) : void 0
+        }, Tweaks
+    }()
+}.call(this), function () {
+    this.Colors = function () {
+        function Colors(colored, solved, tweaks, colors) {
+            null == colors && (colors = ""), this.colored = new Cubexp(colored || "*"), this.solved = new Cubexp(solved), this.tweaks = new Tweaks(tweaks), this.side_colors = Colors._set_colors(colors)
+        }
+
+        var DEFAULT_COLORS;
+        return Colors.prototype.to_draw = function (piece_name, side) {
+            var result, tweak, _i, _len, _ref;
+            for (result = {hovers: !1, color: this.of(side)}, this.solved.matches_sticker(piece_name, side) ? result.color = this.of("solved") : this.colored.matches_sticker(piece_name, side) ? result.hovers = !0 : result.color = this.of("ignored"), _ref = this.tweaks.for_sticker(piece_name, side), _i = 0, _len = _ref.length; _len > _i; _i++)switch (tweak = _ref[_i], result.hovers = !0, tweak) {
+                case"X":
+                case"x":
+                    result.x_color = {X: "black", x: "white"}[tweak];
+                    break;
+                default:
+                    Layer.by_name(tweak) ? result.color = this.of(tweak) : log_error("Unknown tweak: '" + tweak + "'")
+            }
+            return result
+        }, Colors.prototype.of = function (sticker_type) {
+            var type;
+            if (type = sticker_type.name || sticker_type, !this.side_colors[type])throw new Error("Unknown sticker type '" + sticker_type + "'");
+            return this.side_colors[type]
+        }, Colors.prototype.adjust_for = function (drift) {
+            var sc, _ref;
+            return sc = this.side_colors, _ref = [sc[drift.U], sc[drift.D], sc[drift.R], sc[drift.L], sc[drift.F], sc[drift.B]], sc.U = _ref[0], sc.D = _ref[1], sc.R = _ref[2], sc.L = _ref[3], sc.F = _ref[4], sc.B = _ref[5], _ref
+        }, DEFAULT_COLORS = {g: "#0d0", b: "#07f", r: "red", o: "orange", y: "yellow", w: "#eee"}, Colors._set_colors = function (overrides) {
+            var color, dc, override, result, type, _i, _len, _ref, _ref1;
+            for (dc = DEFAULT_COLORS, result = {R: dc.g, L: dc.b, F: dc.r, B: dc.o, U: dc.y, D: dc.w, solved: "#444", ignored: "#888", cube: "black"}, _ref = overrides.split(" "), _i = 0, _len = _ref.length; _len > _i; _i++)override = _ref[_i], _ref1 = override.split(":"), type = _ref1[0], color = _ref1[1], type = {s: "solved", i: "ignored", c: "cube"}[type] || type, result[type] = DEFAULT_COLORS[color] || color;
+            return result
+        }, Colors
+    }()
+}.call(this), function () {
+    this.Config = function () {
+        function Config(config_string) {
+            this.raw_input = Config._parse(config_string), this.base = this.base_config(this.raw_input.base, config_string), this.alg = this.raw("alg"), this.algdisplay = this._alg_display(), this.colors = new Colors(this.raw("colored"), this.raw("solved"), this.raw("tweaks"), this.raw("colors")), this.flags = this.raw("flags"), this.hover = this._hover(), this.pov = this.raw("pov", "Ufr"), this.setup = this.raw("setupmoves"), this.speed = this.raw("speed", 400)
+        }
+
+        return Config.prototype.flag = function (name) {
+            return this.flags.indexOf(name) > -1
+        }, Config.prototype.raw = function (name, default_value) {
+            return null == default_value && (default_value = ""), this.raw_input[name] || this.base.raw(name) || default_value
+        }, Config.prototype.base_config = function (base_id, config_string) {
+            var base_string;
+            return base_string = window["ROOFPIG_CONF_" + base_id], base_id && !base_string && log_error("'ROOFPIG_CONF_" + base_id + "' does not exist"), config_string && config_string === base_string && (log_error("" + base_string + " tries to inherit from itself."), base_string = null), base_string ? new Config(base_string) : {raw: function () {
+            }}
+        }, Config.prototype._hover = function () {
+            var raw_hover;
+            switch (raw_hover = this.raw("hover", "near")) {
+                case"none":
+                    return 1;
+                case"near":
+                    return 2;
+                case"far":
+                    return 7.1;
+                default:
+                    return raw_hover
+            }
+        }, Config.prototype._alg_display = function () {
+            var ad, result;
+            return ad = this.raw("algdisplay"), result = {}, result.fancy2s = ad.indexOf("fancy2s") > -1, result.rotations = ad.indexOf("rotations") > -1, result.Zcode = "2", ad.indexOf("2p") > -1 && (result.Zcode = "2'"), ad.indexOf("Z") > -1 && (result.Zcode = "Z"), result
+        }, Config._parse = function (config_string) {
+            var conf, eq_pos, key, result, value, _i, _len, _ref;
+            if (!config_string)return{};
+            for (result = {}, _ref = config_string.split("|"), _i = 0, _len = _ref.length; _len > _i; _i++)conf = _ref[_i], eq_pos = conf.indexOf("="), key = conf.substring(0, eq_pos).trim(), value = conf.substring(eq_pos + 1).trim(), result[key] = value;
+            return result
+        }, Config
+    }()
+}.call(this), function () {
+    this.Css = function () {
+        function Css() {
+        }
+
+        var dark, light, shadow;
+        return light = "#ededed", dark = "#bbb", shadow = "#ffffff", Css.CODE = "<style>\n.roofpig-button {\n  font-family: Lucida Sans Unicode, Lucida Grande, sans-serif;\n  font-weight: normal;\n  font-style: normal;\n  padding: 0;\n  box-shadow: inset 0px 1px 0px 0px " + shadow + ";\n  background-color: " + light + ";\n  border: 1px solid #dcdcdc;\n  outline: none;\n  border-radius: 2px;\n  text-indent: 0;\n  display: inline-block;\n  text-decoration: none;\n  text-align: center;\n  text-shadow: 1px 1px 0 " + shadow + ";\n}\n.roofpig-button-enabled {\n  background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, " + light + "), color-stop(1, " + dark + "));\n  background: -moz-linear-gradient(center top, " + light + " 5%, " + dark + " 100%);\n  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='" + light + "', endColorstr='" + dark + "');\n}\n.roofpig-button-enabled:hover {\n  background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, " + dark + "), color-stop(1, " + light + "));\n  background: -moz-linear-gradient(center top, " + dark + " 5%, " + light + " 100%);\n  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='" + dark + "', endColorstr='" + light + "');\n}\n.roofpig-button-enabled:active, .roofpig-button-fake-active {\n  position: relative;\n  top: 2px;\n}\n\n.roofpig-count {\n  font-weight: normal;\n  font-style: normal;\n  color: black;\n  text-align: right;\n  float: right;\n}\n\n.roofpig-algtext {\n  background-color: #eee;\n  margin-bottom: 2px;\n  font-weight: normal;\n  font-style: normal;\n  color: black;\n}\n.roofpig-past-algtext {\n  background-color: #ff9;\n}\n\n.roofpig-help-button {\n  font-size: 14px;\n  height: 20px;\n  width: 20px;\n  position: absolute;\n  right: 2px;\n  top: 3px;\n\n  color: #ddd;\n  text-align: center;\n  border-radius: 8px;\n}\n.roofpig-help-button:hover {\n  color: black;\n  background-color: rgba(220, 220, 220, 0.7);\n}\n.roofpig-help-button:active {\n  background-color: #aaa;\n}\n\n.roofpig-help {\n  position: absolute;\n  top: -1px;\n  white-space: nowrap;\n\n  font-size: 10px;\n  font-weight: normal;\n  font-style: normal;\n  color: black;\n  text-align: left;\n  background-color: rgba(255, 255, 255, 0.94);\n\n  border: 1px solid #aaa;\n  padding: 0 4px 4px 4px;\n}\n.roofpig-help div {\n  margin: 2px 0;\n}\n.roofpig-help span {\n  font-size: 11px;\n  padding: 0 2px;\n  background-color: #ddd;\n}\n</style>", Css
+    }()
+}.call(this), function () {
+    this.Dom = function () {
+        function Dom(cube_id, div, renderer) {
+            this.cube_id = cube_id, this.div = div, this.div.css({position: "relative", "font-family": '"Lucida Sans Unicode", "Lucida Grande", sans-serif'}), this.has_focus(!1), this.div.data("cube_id", this.cube_id), renderer.setSize(this.div.width(), this.div.width()), this.div.append(renderer.domElement), this.scale = this.div.width() / 400, this.hscale = Math.max(this.scale, .375)
+        }
+
+        var LUCIDA_WIDTHS;
+        return Dom.prototype.has_focus = function (has_it) {
+            var color, cursor;
+            return color = has_it ? "gray" : "#eee", cursor = has_it ? "pointer" : "default", this.div.css({border: "2px solid " + color, cursor: cursor})
+        }, Dom.prototype.alg_changed = function (is_playing, at_start, at_end, count_text, alg_texts) {
+            var button, _i, _j, _len, _len1, _ref, _ref1;
+            if (is_playing)for (_ref = this.buttons, _i = 0, _len = _ref.length; _len > _i; _i++)button = _ref[_i], button === this.play ? button.hide() : this._show(button, button === this.pause); else for (_ref1 = this.buttons, _j = 0, _len1 = _ref1.length; _len1 > _j; _j++)switch (button = _ref1[_j]) {
+                case this.reset:
+                case this.prev:
+                    this._show(button, !at_start);
+                    break;
+                case this.next:
+                case this.play:
+                    this._show(button, !at_end);
+                    break;
+                case this.pause:
+                    button.hide()
+            }
+            return this.play_or_pause = is_playing ? this.pause : this.play, this.count.html(count_text), this.alg_text ? (this.alg_past.text(alg_texts.past), this.alg_future.text(" " + alg_texts.future)) : void 0
+        }, Dom.prototype.show_help = function () {
+            return this.help = $("<div/>").addClass("roofpig-help"), this.help.append($("<div>Keyboard shortcuts</div>").css({"text-align": "center", "font-weight": "bold"}), "<div><span>→</span> - Next move</div>", "<div/><span>←</span> - Previous move</div>", "<div/><span>⇧</span>+<span>→</span> - To end</div>", "<div/><span>⇧</span>+<span>←</span> - To start</div>", "<div/><span>&nbsp;space&nbsp;</span> - Play/Pause</div>", "<div/><span>Tab</span> - Next Cube</div>"), this.div.append(this.help), this.help.css({right: "" + (this.div.width() - this.help.outerWidth()) / 2 + "px"})
+        }, Dom.prototype.remove_help = function () {
+            var was_removed;
+            return this.help && (this.help.remove(), this.help = null, was_removed = !0), was_removed
+        }, Dom.prototype.add_alg_area = function (showalg) {
+            return this.div.append($("<div/>", {text: "?", id: "help-" + this.cube_id}).addClass("roofpig-help-button")), this.alg_area = $("<div/>").height(this.div.height() - this.div.width()).width(this.div.width()).css({"border-top": "1px solid #ccc"}), this.div.append(this.alg_area), showalg && (this.alg_text = $("<div/>").width(this.div.width()).addClass("roofpig-algtext"), this.alg_area.append(this.alg_text), this.alg_past = $("<span/>").addClass("roofpig-past-algtext"), this.alg_future = $("<span/>"), this.alg_text.append(this.alg_past, this.alg_future)), this.reset = this._make_button("↩", "reset"), this.prev = this._make_button("-", "prev"), this.next = this._make_button("+", "next"), this.pause = this._make_button("Ⅱ", "pause"), this.play = this._make_button("▶", "play"), this.count = this._make_count_area(), this.buttons = [this.reset, this.prev, this.next, this.pause, this.play]
+        }, LUCIDA_WIDTHS = {M: 108, "+": 100, ">": 100, "<": 100, w: 98, D: 94, U: 87, 2: 80, R: 80, x: 78, Z: 77, B: 73, z: 73, F: 68, E: 68, S: 68, L: 67, y: 65, "²": 53, " ": 40, "'": 29}, Dom.prototype.init_alg_text = function (text) {
+            var char, font_size, width, _i, _len, _ref;
+            if (this.alg_text) {
+                for (width = 0, _ref = text.split(""), _i = 0, _len = _ref.length; _len > _i; _i++)char = _ref[_i], width += LUCIDA_WIDTHS[char] || 80, LUCIDA_WIDTHS[char] || log_error("Unknown char width: '" + char + "'");
+                return font_size = 24 * this.scale * Math.min(1, 1970 / width), this.alg_text.height(1.2 * font_size).css({"font-size": font_size})
+            }
+        }, Dom.prototype._show = function (button, enabled) {
+            return button.show(), enabled ? (button.removeAttr("disabled"), button.addClass("roofpig-button-enabled")) : (button.attr("disabled", "disabled"), button.removeClass("roofpig-button-enabled"))
+        }, Dom.prototype._make_button = function (text, name) {
+            var button;
+            return button = $("<button/>", {text: text, id: "" + name + "-" + this.cube_id}), this.alg_area.append(button), button.addClass("roofpig-button"), button.css({"font-size": 28 * this.hscale, "float": "left", height: 40 * this.hscale, width: 76 * this.scale})
+        }, Dom.prototype._make_count_area = function () {
+            var count_div;
+            return count_div = $("<div/>", {id: "count-" + this.cube_id}).addClass("roofpig-count"), this.alg_area.append(count_div), count_div.height(40 * this.hscale).width(80 * this.scale).css("font-size", 24 * this.hscale)
+        }, Dom
+    }()
+}.call(this), function () {
+    this.OneChange = function () {
+        function OneChange(action) {
+            this.action = action
+        }
+
+        return OneChange.prototype.update = function () {
+            return this.action()
+        }, OneChange.prototype.finish = function () {
+        }, OneChange.prototype.finished = function () {
+            return!0
+        }, OneChange
+    }()
+}.call(this), function () {
+    var __indexOf = [].indexOf || function (item) {
+        for (var i = 0, l = this.length; l > i; i++)if (i in this && this[i] === item)return i;
+        return-1
+    };
+    this.EventHandlers = function () {
+        function EventHandlers() {
+        }
+
+        var button_keys, key_A, key_C, key_D, key_J, key_K, key_L, key_S, key_X, key_Z, key_down_arrow, key_end, key_home, key_left_arrow, key_question, key_right_arrow, key_space, key_tab, key_up_arrow, rotate_keys, side_for, turn_keys;
+        return EventHandlers.set_focus = function (new_focus) {
+            return this.focus !== new_focus ? (this.focus && this.dom.has_focus(!1), this.focus = new_focus, this.camera = this.focus.camera, this.dom = this.focus.dom, this.dom.has_focus(!0)) : void 0
+        }, EventHandlers.initialize = function () {
+            return $("body").keydown(function (e) {
+                return EventHandlers.key_down(e)
+            }), $("body").keyup(function (e) {
+                return EventHandlers.key_up(e)
+            }), $(".roofpig").mousedown(function (e) {
+                return EventHandlers.mouse_down(e, $(this).data("cube_id"))
+            }), $("body").mousemove(function (e) {
+                return EventHandlers.mouse_move(e)
+            }), $("body").mouseup(function (e) {
+                return EventHandlers.mouse_end(e)
+            }), $("body").mouseleave(function (e) {
+                return EventHandlers.mouse_end(e)
+            }), $(".roofpig").click(function () {
+                var cube;
+                return cube = CubeAnimation.by_id[$(this).data("cube_id")], EventHandlers.set_focus(cube)
+            }), $("button").click(function (e) {
+                var button_name, cube_id, _ref;
+                return _ref = $(this).attr("id").split("-"), button_name = _ref[0], cube_id = _ref[1], CubeAnimation.by_id[cube_id].button_click(button_name, e.shiftKey)
+            }), $(".roofpig-help-button").click(function () {
+                var cube_id, _, _ref;
+                return _ref = $(this).attr("id").split("-"), _ = _ref[0], cube_id = _ref[1], CubeAnimation.by_id[cube_id].dom.show_help()
+            })
+        }, EventHandlers.mouse_down = function (e, clicked_cube_id) {
+            return this.dom.remove_help(), clicked_cube_id === this.focus.id ? (this.bend_start_x = e.pageX, this.bend_start_y = e.pageY, this.bending = !0) : void 0
+        }, EventHandlers.mouse_end = function () {
+            return this.focus.add_changer("camera", new OneChange(function (_this) {
+                return function () {
+                    return _this.camera.bend(0, 0)
+                }
+            }(this))), this.bending = !1
+        }, EventHandlers.mouse_move = function (e) {
+            var dx, dy;
+            return this.bending ? (dx = -.02 * (e.pageX - this.bend_start_x) / this.dom.scale, dy = -.02 * (e.pageY - this.bend_start_y) / this.dom.scale, e.shiftKey && (dy = 0), this.focus.add_changer("camera", new OneChange(function (_this) {
+                return function () {
+                    return _this.camera.bend(dx, dy)
+                }
+            }(this)))) : void 0
+        }, EventHandlers.key_down = function (e) {
+            var alt, axis, help_toggled, key, new_focus, shift, turns, unhandled, _ref;
+            return help_toggled = this.dom.remove_help(), e.ctrlKey || e.metaKey ? !0 : (_ref = [e.keyCode, e.shiftKey, e.altKey], key = _ref[0], shift = _ref[1], alt = _ref[2], key === key_tab ? (new_focus = shift ? this.focus.previous_cube() : this.focus.next_cube(), this.set_focus(new_focus)) : key === key_end || key === key_right_arrow && shift ? this.focus.add_changer("pieces", new OneChange(function (_this) {
+                return function () {
+                    return _this.focus.alg.to_end(_this.focus.world3d)
+                }
+            }(this))) : __indexOf.call(button_keys, key) >= 0 ? this._fake_click_down(this._button_for(key, shift)) : __indexOf.call(rotate_keys, key) >= 0 ? (axis = function () {
+                switch (key) {
+                    case key_C:
+                    case key_Z:
+                        return"up";
+                    case key_A:
+                    case key_D:
+                        return"dr";
+                    case key_S:
+                    case key_X:
+                        return"dl"
+                }
+            }(), turns = function () {
+                switch (key) {
+                    case key_C:
+                    case key_A:
+                    case key_S:
+                        return 1;
+                    case key_Z:
+                    case key_D:
+                    case key_X:
+                        return-1
+                }
+            }(), this._rotate(axis, turns)) : __indexOf.call(turn_keys, key) >= 0 ? (turns = shift ? 3 : alt ? 2 : 1, this._move("" + side_for[key] + turns)) : key === key_question ? help_toggled || this.focus.dom.show_help() : unhandled = !0, unhandled ? void 0 : (e.preventDefault(), e.stopPropagation()))
+        }, EventHandlers._button_for = function (key, shift) {
+            switch (key) {
+                case key_home:
+                    return this.dom.reset;
+                case key_left_arrow:
+                    return shift ? this.dom.reset : this.dom.prev;
+                case key_right_arrow:
+                    return this.dom.next;
+                case key_space:
+                    return this.dom.play_or_pause
+            }
+        }, EventHandlers.key_up = function (e) {
+            var button_key, _ref;
+            return _ref = e.keyCode, button_key = __indexOf.call(button_keys, _ref) >= 0, button_key && this.down_button && (this._fake_click_up(this.down_button), this.down_button = null), button_key
+        }, EventHandlers._fake_click_down = function (button) {
+            return button.attr("disabled") ? void 0 : (this.down_button = button, button.addClass("roofpig-button-fake-active"))
+        }, EventHandlers._fake_click_up = function (button) {
+            return button.attr("disabled") ? void 0 : (button.removeClass("roofpig-button-fake-active"), button.click())
+        }, EventHandlers._rotate = function (axis_name, turns) {
+            var angle_to_turn;
+            return angle_to_turn = -Math.PI / 2 * turns, this.focus.add_changer("camera", new CameraMovement(this.camera, this.camera.user_dir[axis_name], angle_to_turn, 500, !0))
+        }, EventHandlers._move = function (code) {
+            return this.focus.add_changer("pieces", new Move(code, this.focus.world3d, 200).show_do())
+        }, key_tab = 9, key_space = 32, key_end = 35, key_home = 36, key_left_arrow = 37, key_up_arrow = 38, key_right_arrow = 39, key_down_arrow = 40, key_A = 65, key_C = 67, key_D = 68, key_J = 74, key_K = 75, key_L = 76, key_S = 83, key_X = 88, key_Z = 90, key_question = 191, button_keys = [key_space, key_home, key_left_arrow, key_right_arrow], rotate_keys = [key_C, key_Z, key_A, key_D, key_S, key_X], turn_keys = [key_J, key_K, key_L], side_for = {}, side_for[key_J] = "U", side_for[key_K] = "F", side_for[key_L] = "R", EventHandlers
+    }()
+}.call(this), function () {
+    this.Pieces3D = function () {
+        function Pieces3D(scene, config, use_canvas) {
+            this.use_canvas = use_canvas, this.at = {}, this.cube_surfaces = this.use_canvas ? [!0] : [!0, !1], this.sticker_size = this.use_canvas ? .84 : .9, this.hover_size = this.use_canvas ? .91 : .97, this.make_stickers(scene, config.hover, config.colors)
+        }
+
+        var TINY;
+        return TINY = .003, Pieces3D.prototype.on = function (layer) {
+            var position, _i, _len, _ref, _results;
+            for (_ref = layer.positions, _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)position = _ref[_i], _results.push(this.at[position]);
+            return _results
+        }, Pieces3D.prototype.move = function (layer, turns) {
+            var positive_turns;
+            return positive_turns = (turns + 4) % 4, this._track_stickers(layer, positive_turns), this._track_pieces(positive_turns, layer.cycle1, layer.cycle2)
+        }, Pieces3D.prototype.state = function () {
+            var piece, result, _i, _len, _ref;
+            for (result = "", _ref = ["B", "BL", "BR", "D", "DB", "DBL", "DBR", "DF", "DFL", "DFR", "DL", "DR", "F", "FL", "FR", "L", "R", "U", "UB", "UBL", "UBR", "UF", "UFL", "UFR", "UL", "UR"], _i = 0, _len = _ref.length; _len > _i; _i++)piece = _ref[_i], result += this[piece].sticker_locations.join("") + " ";
+            return result
+        }, Pieces3D.prototype._track_stickers = function (layer, turns) {
+            var item, piece, _i, _len, _ref, _results;
+            for (_ref = this.on(layer), _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)piece = _ref[_i], _results.push(piece.sticker_locations = function () {
+                var _j, _len1, _ref1, _results1;
+                for (_ref1 = piece.sticker_locations, _results1 = [], _j = 0, _len1 = _ref1.length; _len1 > _j; _j++)item = _ref1[_j], _results1.push(layer.shift(item, turns));
+                return _results1
+            }());
+            return _results
+        }, Pieces3D.prototype._track_pieces = function (turns, cycle1, cycle2) {
+            var n, _i, _results;
+            for (_results = [], n = _i = 1; turns >= 1 ? turns >= _i : _i >= turns; n = turns >= 1 ? ++_i : --_i)this._permute(cycle1), _results.push(this._permute(cycle2));
+            return _results
+        }, Pieces3D.prototype._permute = function (p) {
+            var _ref;
+            return _ref = [this.at[p[1]], this.at[p[2]], this.at[p[3]], this.at[p[0]]], this.at[p[0]] = _ref[0], this.at[p[1]] = _ref[1], this.at[p[2]] = _ref[2], this.at[p[3]] = _ref[3], _ref
+        }, Pieces3D.prototype.make_stickers = function (scene, hover, colors) {
+            var piece, side, slice, sticker_look, x_side, y_side, z_side, _i, _len, _ref, _results;
+            for (slice = {normal: v3(0, 0, 0), name: "-"}, _ref = [Layer.R, slice, Layer.L], _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)x_side = _ref[_i], _results.push(function () {
+                var _j, _len1, _ref1, _results1;
+                for (_ref1 = [Layer.F, slice, Layer.B], _results1 = [], _j = 0, _len1 = _ref1.length; _len1 > _j; _j++)y_side = _ref1[_j], _results1.push(function () {
+                    var _k, _l, _len2, _len3, _ref2, _ref3, _results2;
+                    for (_ref2 = [Layer.U, slice, Layer.D], _results2 = [], _k = 0, _len2 = _ref2.length; _len2 > _k; _k++) {
+                        for (z_side = _ref2[_k], piece = this._new_piece(x_side, y_side, z_side), _ref3 = [x_side, y_side, z_side], _l = 0, _len3 = _ref3.length; _len3 > _l; _l++)side = _ref3[_l], side !== slice && (sticker_look = colors.to_draw(piece.name, side), this._add_sticker(side, piece, sticker_look), sticker_look.hovers && hover > 1 && this._add_hover_sticker(side, piece, sticker_look, hover), this._add_cubeside(side, piece, colors.of("cube")));
+                        this[piece.name] = this.at[piece.name] = piece, _results2.push(scene.add(piece))
+                    }
+                    return _results2
+                }.call(this));
+                return _results1
+            }.call(this));
+            return _results
+        }, Pieces3D.prototype._new_piece = function (x_side, y_side, z_side) {
+            var new_piece;
+            return new_piece = new THREE.Object3D, new_piece.name = standardize_name(x_side.name + y_side.name + z_side.name), new_piece.sticker_locations = new_piece.name.split(""), new_piece.middle = v3(2 * x_side.normal.x, 2 * y_side.normal.y, 2 * z_side.normal.z), new_piece
+        }, Pieces3D.prototype._add_sticker = function (side, piece_3d, sticker) {
+            var dx, dy, _ref;
+            return _ref = this._offsets(side.normal, this.sticker_size, !1), dx = _ref[0], dy = _ref[1], piece_3d.add(this._diamond(this._square_center(side, piece_3d.middle, 1 + TINY), dx, dy, sticker.color)), sticker.x_color ? this._add_X(side, piece_3d, sticker.x_color, 1 + 2 * TINY, !0) : void 0
+        }, Pieces3D.prototype._add_hover_sticker = function (side, piece_3d, sticker, hover) {
+            var dx, dy, _ref;
+            return _ref = this._offsets(side.normal, this.hover_size, !0), dx = _ref[0], dy = _ref[1], piece_3d.add(this._diamond(this._square_center(side, piece_3d.middle, hover), dx, dy, sticker.color)), sticker.x_color ? this._add_X(side, piece_3d, sticker.x_color, hover - TINY, !1) : void 0
+        }, Pieces3D.prototype._add_cubeside = function (side, piece_3d, color) {
+            var dx, dy, reversed, _i, _len, _ref, _ref1, _results;
+            for (_ref = this.cube_surfaces, _results = [], _i = 0, _len = _ref.length; _len > _i; _i++)reversed = _ref[_i], _ref1 = this._offsets(side.normal, 1, reversed), dx = _ref1[0], dy = _ref1[1], _results.push(piece_3d.add(this._diamond(this._square_center(side, piece_3d.middle, 1), dx, dy, color)));
+            return _results
+        }, Pieces3D.prototype._add_X = function (side, piece_3d, color, distance, reversed) {
+            var center, dx, dy, _ref;
+            return _ref = this._offsets(side.normal, .54, reversed), dx = _ref[0], dy = _ref[1], center = this._square_center(side, piece_3d.middle, distance), piece_3d.add(this._rect(center, dx, v3_x(dy, .14), color)), piece_3d.add(this._rect(center, v3_x(dx, .14), dy, color))
+        }, Pieces3D.prototype._square_center = function (side, piece_center, distance) {
+            return v3_add(piece_center, v3_x(side.normal, distance))
+        }, Pieces3D.prototype._rect = function (center, d1, d2, color) {
+            return this._diamond(center, v3_add(d1, d2), v3_sub(d1, d2), color)
+        }, Pieces3D.prototype._diamond = function (center, d1, d2, color) {
+            var geo;
+            return geo = new THREE.Geometry, geo.vertices.push(v3_add(center, d1), v3_add(center, d2), v3_sub(center, d1), v3_sub(center, d2)), geo.faces.push(new THREE.Face3(0, 1, 2), new THREE.Face3(0, 2, 3)), geo.computeFaceNormals(), geo.computeBoundingSphere(), new THREE.Mesh(geo, new THREE.MeshBasicMaterial({color: color, overdraw: .8}))
+        }, Pieces3D.prototype._offsets = function (axis1, sticker_size, reversed) {
+            var axis2, axis3, dx, dy, flip;
+            return axis2 = v3(axis1.y, axis1.z, axis1.x), axis3 = v3(axis1.z, axis1.x, axis1.y), flip = (axis1.y + axis1.z + axis1.x) * (reversed ? -1 : 1), dx = v3_add(axis2, axis3).multiplyScalar(sticker_size * flip), dy = v3_sub(axis2, axis3).multiplyScalar(sticker_size), [dx, dy]
+        }, Pieces3D
+    }()
+}.call(this), function () {
+    var __hasProp = {}.hasOwnProperty;
+    this.CubeAnimation = function () {
+        function CubeAnimation(roofpig_div, webgl_works, canvas_works) {
+            var use_canvas;
+            return canvas_works ? (this.id = CubeAnimation.last_id += 1, CubeAnimation.by_id[this.id] = this, this.config = new Config(roofpig_div.data("config")), use_canvas = this.config.flag("canvas") || !webgl_works || CubeAnimation.webgl_cubes >= 16, use_canvas ? this.renderer = new THREE.CanvasRenderer({alpha: !0}) : (CubeAnimation.webgl_cubes += 1, this.renderer = new THREE.WebGLRenderer({antialias: !0, alpha: !0})), this.dom = new Dom(this.id, roofpig_div, this.renderer), this.scene = new THREE.Scene, this.camera = new Camera(this.config.hover, this.config.pov), "" === this.config.alg ? (this.world3d = {camera: this.camera, pieces: new Pieces3D(this.scene, this.config, use_canvas)}, this.config.setup && new Alg(this.config.setup, this.world3d).to_end()) : (this.world3d = {camera: this.camera}, this.dom.add_alg_area(this.config.flag("showalg")), this.alg = new Alg(this.config.alg, this.world3d, this.config.algdisplay, this.config.speed, this.dom), this.config.colors.adjust_for(this.alg.side_drift()), this.world3d.pieces = new Pieces3D(this.scene, this.config, use_canvas), this.config.setup && new Alg(this.config.setup, this.world3d).to_end(), this.alg.mix()), 1 === this.id && EventHandlers.set_focus(this), this.changers = {}, void this.animate(!0)) : (roofpig_div.html("Your browser does not support <a href='http://khronos.org/webgl/wiki/Getting_a_WebGL_Implementation'>WebGL</a>.<p/> Find out how to get it <a href='http://get.webgl.org/'>here</a>."), void roofpig_div.css({background: "#f66"}))
+        }
+
+        return CubeAnimation.last_id = 0, CubeAnimation.by_id = [], CubeAnimation.webgl_cubes = 0, CubeAnimation.prototype.next_cube = function () {
+            var next_id;
+            return next_id = this.id % CubeAnimation.last_id + 1, CubeAnimation.by_id[next_id]
+        }, CubeAnimation.prototype.previous_cube = function () {
+            var prev_id;
+            return prev_id = (this.id + CubeAnimation.last_id - 2) % CubeAnimation.last_id + 1, CubeAnimation.by_id[prev_id]
+        }, CubeAnimation.prototype.animate = function (first_time) {
+            var any_change, category, changer, now, _ref;
+            null == first_time && (first_time = !1), now = (new Date).getTime(), _ref = this.changers;
+            for (category in _ref)__hasProp.call(_ref, category) && (changer = _ref[category], changer && (changer.update(now), changer.finished() && (this.changers[category] = null), any_change = !0));
+            return(any_change || first_time) && this.renderer.render(this.scene, this.camera.cam), requestAnimationFrame(function (_this) {
+                return function () {
+                    return _this.animate()
+                }
+            }(this))
+        }, CubeAnimation.prototype.add_changer = function (category, changer) {
+            return this.changers[category] && this.changers[category].finish(), this.changers[category] = changer
+        }, CubeAnimation.prototype.button_click = function (name, shift) {
+            var changer;
+            switch (name) {
+                case"play":
+                    changer = shift ? new OneChange(function (_this) {
+                        return function () {
+                            return _this.alg.to_end(_this.world3d)
+                        }
+                    }(this)) : this.alg.play(this.world3d);
+                    break;
+                case"pause":
+                    this.alg.stop();
+                    break;
+                case"next":
+                    this.alg.at_end() || (changer = this.alg.next_move().show_do(this.world3d));
+                    break;
+                case"prev":
+                    this.alg.at_start() || (changer = this.alg.prev_move().show_undo(this.world3d));
+                    break;
+                case"reset":
+                    changer = new OneChange(function (_this) {
+                        return function () {
+                            return _this.alg.to_start(_this.world3d)
+                        }
+                    }(this))
+            }
+            return changer ? this.add_changer("pieces", changer) : void 0
+        }, CubeAnimation
+    }()
+}.call(this), function () {
+    $(document).ready(function () {
+        var canvas_browser, roofpig_div, webgl_browser, _i, _len, _ref;
+        for (console.log("Roofpig version 1.1 (2014-07-11 14:59). Expecting jQuery 1.11.1 and Three.js 67."), console.log("jQuery version", $.fn.jquery), $("head").append(Css.CODE), webgl_browser = function () {
+            var e;
+            try {
+                return!!window.WebGLRenderingContext && !!document.createElement("canvas").getContext("experimental-webgl")
+            } catch (_error) {
+                return e = _error, !1
+            }
+        }(), canvas_browser = !!window.CanvasRenderingContext2D, canvas_browser ? webgl_browser || log_error("No WebGL support in this browser. Falling back on regular Canvas.") : log_error("No Canvas support in this browser. Giving up."), _ref = $(".roofpig"), _i = 0, _len = _ref.length; _len > _i; _i++)roofpig_div = _ref[_i], new CubeAnimation($(roofpig_div), webgl_browser, canvas_browser);
+        return EventHandlers.initialize()
+    })
+}.call(this);

--- a/views/solve.erb
+++ b/views/solve.erb
@@ -60,7 +60,7 @@
           <span id="roofpig-arrow" class="arrow glyphicon glyphicon-chevron-right"></span>
       </h3></a>
       <div id="roofpig">
-        <div class="roofpig" data-config="<%= roofpig_form(@solve) %>"></div>
+        <div class="roofpig" data-config="alg=<%= roofpig_form(@solve) %>|colors=F:g B:b U:w D:y R:r L:o"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Latest version fixes the applet so that color scheme defines the start orientation not the end orientation. I also defined the applet's start orientation to white on U, green on F. 

lib/views/roofpig_former.erb should now correctly remove parentheses from solutions. 
